### PR TITLE
Add /doc/tags to a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # Ignore generated tags
-/doc/tags/
+/doc/tags


### PR DESCRIPTION
Other hide options should be considered, but this at least hides the
auto generated tags. This is probably only a problem for those pulling
the project in submodules.
