### PR TITLE
Do not try to close the last window

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -904,7 +904,7 @@ function! s:Close()
     let listed = filter(copy(s:MRUList), "buflisted(v:val)")
 
     " If we needed to split the main window, close the split one.
-    if s:splitMode != ""
+    if s:splitMode != "" && bufwinnr(s:originBuffer) != -1
         execute "wincmd c"
     endif
 


### PR DESCRIPTION
Hello,

Vim complains “Cannot close the last window” when one tries to do the following:
1. Open two files.
2. Open bufexplorer in the split mode.
3. Delete the current buffer from the list.
4. Select the one that is left.

Best wishes,
Ivan
