### PR TITLE
Close even if the target buffer has not been loaded yet

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -808,6 +808,8 @@ function! s:SelectBuffer(...)
                     let _bufName = expand("#"._bufNbr.":p")
                     execute _bufName ? "drop ".escape(_bufName, " ") : "buffer "._bufNbr
                 endif
+            else
+                call s:Close()
             endif
 
             " Switch to the selected buffer.


### PR DESCRIPTION
Hello,

When working in split mode, BufExplorer does not close itself if the selected buffer has not been loaded yet. Here is how the behavior can be reproduced:
1. Issue the `vim` command with more than one file (`$ vim one.txt two.txt`).
2. Open BufExplorer in split mode and see that the other buffer is shaded (= not loaded).
3. Open that other buffer and see that it opens right in the split replacing BufExplorer and leaving two windows open. 

I have tested it as much as I could, and it works for me. However, since I am not that familiar with the code base, I could miss some scenario. If it is the case, please let me know, and I will fix the pull request.

Thank you! 

Best wishes,
Ivan
