### PR TITLE
Revert "Close even if the target buffer has not been loaded yet"

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -808,8 +808,6 @@ function! s:SelectBuffer(...)
                     let _bufName = expand("#"._bufNbr.":p")
                     execute _bufName ? "drop ".escape(_bufName, " ") : "buffer "._bufNbr
                 endif
-            else
-                call s:Close()
             endif
 
             " Switch to the selected buffer.


### PR DESCRIPTION
Hello,

The pull request reverts the change introduced by [Pull Request #11](https://github.com/jlanzarotta/bufexplorer/pull/11). I apologize for the inconvenience.

Regards,
Ivan
