### PR TITLE
Unmap mappings in Select mode so they don’t interfere

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1203,14 +1203,17 @@ call s:Set("g:bufExplorerSplitHorzSize", 0)             " Height for a horizonta
 " Default key mapping {{{1
 if !hasmapto('BufExplorer') && g:bufExplorerDisableDefaultKeyMapping == 0
     noremap <script> <silent> <unique> <Leader>be :BufExplorer<CR>
+    sunmap  <script> <silent> <unique> <Leader>be
 endif
 
 if !hasmapto('BufExplorerHorizontalSplit') && g:bufExplorerDisableDefaultKeyMapping == 0
     noremap <script> <silent> <unique> <Leader>bs :BufExplorerHorizontalSplit<CR>
+    sunmap  <script> <silent> <unique> <Leader>bs
 endif
 
 if !hasmapto('BufExplorerVerticalSplit') && g:bufExplorerDisableDefaultKeyMapping == 0
     noremap <script> <silent> <unique> <Leader>bv :BufExplorerVerticalSplit<CR>
+    sunmap  <script> <silent> <unique> <Leader>bv
 endif
 
 " vim:ft=vim foldmethod=marker sw=4


### PR DESCRIPTION
`map` and `vmap`, surprisingly, apply not only to Visual mode but also to [Select mode](http://vimdoc.sourceforge.net/htmldoc/visual.html#Select). (See [`:help mapmode-s`](http://vimdoc.sourceforge.net/htmldoc/map.html#mapmode-s).) However, this doesn’t make sense if the mapping contains a printable character, which it often does – it stops the user from typing that character and seeing the result immediately. So you have to use `sunmap` to remove it (or use `xmap` instead of `vmap`.)
