### PR TITLE
bug fix

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -112,6 +112,8 @@ let s:sort_by = ["number", "name", "fullpath", "mru", "extension"]
 let s:splitMode = ""
 let s:tabSpace = []
 let s:types = {"fullname": ':p', "path": ':p:h', "relativename": ':~:.', "relativepath": ':~:.:h', "shortname": ':t'}
+let s:altBufferOnEntry = ""
+let s:activeBufferOnEntry = ""
 
 " Setup the autocommands that handle the MRUList and other stuff. {{{2
 autocmd VimEnter * call s:Setup()
@@ -683,6 +685,12 @@ function! s:BuildBufferList()
             endif
         endif
 
+        if buf.attributes =~ "%"
+            let s:activeBufferOnEntry = matchstr(buf.attributes, '[0-9]\+')
+        elseif buf.attributes =~ "#"
+            let s:altBufferOnEntry =  matchstr(buf.attributes, '[0-9]\+')
+        endif
+
         let line = buf.attributes." "
 
         " Are we to split the path and file name?
@@ -916,9 +924,8 @@ function! s:Close()
     else
         " Since there are buffers left to switch to, swith to the previous and
         " then the current.
-        for b in reverse(listed[0:1])
-            execute "keepjumps silent b ".b
-        endfor
+        execute "keepjumps silent b ".s:altBufferOnEntry
+        execute "keepjumps silent b ".s:activeBufferOnEntry
     endif
 
     " Clear any messages.


### PR DESCRIPTION
when quitting the bufexplorer window using the 'q' mapping, switch to the previously active buffer rather than the first buffer in the list also, preserve the correct alt buffer so that <C-^> works.

The bug was as follows:

I have 3 files open.  The first buffer (ie buffer with the lowest buffer number) is the alternate buffer, ie hidden and the one that I was editing before switching to the current buffer.  The second buffer is the current buffer.

I go into bufexplorer.  I decide that I didn't want to switch buffer after all, so I leave the cursor on the line where it was to start with (ie the current buffer) and I press return.  I expect to return to the current buffer but to my surprise I land in the alternate buffer.

If I am editing the first buffer, go into bufexplorer, change mind and hit return then I land in the first buffer as expected.

I uninstalled almost all my plugins and retested to see if that made a difference, and it didn't.