### PR TITLE
Change "noremap" to "nnoremap" to avoid unexpected mapping modes.

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -50,9 +50,9 @@
 "               Or you can override the defaults and define your own mapping
 "               in your vimrc file, for example:
 "
-"                   noremap <silent> <F11> :BufExplorer<CR>
-"                   noremap <silent> <m-F11> :BufExplorerHorizontalSplit<CR>
-"                   noremap <silent> <c-F11> :BufExplorerVerticalSplit<CR>
+"                   nnoremap <silent> <F11> :BufExplorer<CR>
+"                   nnoremap <silent> <m-F11> :BufExplorerHorizontalSplit<CR>
+"                   nnoremap <silent> <c-F11> :BufExplorerVerticalSplit<CR>
 "
 "               Or you can use
 "
@@ -1202,15 +1202,15 @@ call s:Set("g:bufExplorerSplitHorzSize", 0)             " Height for a horizonta
 
 " Default key mapping {{{1
 if !hasmapto('BufExplorer') && g:bufExplorerDisableDefaultKeyMapping == 0
-    noremap <script> <silent> <unique> <Leader>be :BufExplorer<CR>
+    nnoremap <script> <silent> <unique> <Leader>be :BufExplorer<CR>
 endif
 
 if !hasmapto('BufExplorerHorizontalSplit') && g:bufExplorerDisableDefaultKeyMapping == 0
-    noremap <script> <silent> <unique> <Leader>bs :BufExplorerHorizontalSplit<CR>
+    nnoremap <script> <silent> <unique> <Leader>bs :BufExplorerHorizontalSplit<CR>
 endif
 
 if !hasmapto('BufExplorerVerticalSplit') && g:bufExplorerDisableDefaultKeyMapping == 0
-    noremap <script> <silent> <unique> <Leader>bv :BufExplorerVerticalSplit<CR>
+    nnoremap <script> <silent> <unique> <Leader>bv :BufExplorerVerticalSplit<CR>
 endif
 
 " vim:ft=vim foldmethod=marker sw=4


### PR DESCRIPTION
The "noremap" command puts mappings in place for normal, visual, select,
and operator-pending modes.  This is unnecessarily broad and can cause
problems, especially for select mode.  The select-mode behavior Vim
promises[1](and therefore users expect) is that typing any printable
character should cause the selection to be deleted, insert mode to be
entered, and the typed character to be inserted into the buffer.  When a
select-mode mapping begins with a printable character, the expected
behavior is no longer provided.  This can surprise users by performing
an action instead of entering their text, or by delaying their
keystrokes until the mapping cannot be matched.

Instead of "noremap", the "nnoremap" command creates only a normal-mode
mapping, which is the expected behavior for a command-like mapping.

[1]: See ":help select-mode" for details.
