### PR TITLE
Add toggle command

### DIFF
--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -42,6 +42,8 @@ USAGE                                                      *bufexplorer-usage*
 
 To start exploring in the current window, use: >
  \be   or   :BufExplorer   or   Your custom key mapping
+To toggle bufexplorer on or off in the current window, use:
+ \bt   or   :ToggleBufExplorer   or   Your custom key mapping
 To start exploring in a newly split horizontal window, use: >
  \bs   or   :BufExplorerHorizontalSplit   or   Your custom key mapping
 To start exploring in a newly split vertical window, use: >
@@ -130,6 +132,7 @@ override bufexplorer's default mappings by setting up something like the
 following in your vimrc file:
 
   noremap <silent> <F11> :BufExplorer<CR>
+  noremap <silent> <s-F11> :ToggleBufExplorer<CR>
   noremap <silent> <m-F11> :BufExplorerHorizontalSplit<CR>
   noremap <silent> <c-F11> :BufExplorerVerticalSplit<CR>
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -44,6 +44,7 @@
 "               You may use the default keymappings of
 "
 "                 <Leader>be  - Opens BufExplorer
+"                 <Leader>bt  - Toggles BufExplorer open or closed
 "                 <Leader>bs  - Opens horizontally split window BufExplorer
 "                 <Leader>bv  - Opens vertically split window BufExplorer
 "
@@ -51,6 +52,7 @@
 "               in your vimrc file, for example:
 "
 "                   noremap <silent> <F11> :BufExplorer<CR>
+"                   noremap <silent> <s-F11> :ToggleBufExplorer<CR>
 "                   noremap <silent> <m-F11> :BufExplorerHorizontalSplit<CR>
 "                   noremap <silent> <c-F11> :BufExplorerVerticalSplit<CR>
 "
@@ -913,7 +915,6 @@ endfunction
 function! s:Close()
     " Get only the listed buffers.
     let listed = filter(copy(s:MRUList), "buflisted(v:val)")
-
     " If we needed to split the main window, close the split one.
     if s:splitMode != "" && bufwinnr(s:originBuffer) != -1
         execute "wincmd c"
@@ -925,7 +926,7 @@ function! s:Close()
         " buffers.
         execute "enew"
     else
-        " Since there are buffers left to switch to, swith to the previous and
+        " Since there are buffers left to switch to, switch to the previous and
         " then the current.
         for b in reverse(listed[0:1])
             execute "keepjumps silent b ".b
@@ -1214,6 +1215,10 @@ call s:Set("g:bufExplorerSplitHorzSize", 0)             " Height for a horizonta
 " Default key mapping {{{1
 if !hasmapto('BufExplorer') && g:bufExplorerDisableDefaultKeyMapping == 0
     noremap <script> <silent> <unique> <Leader>be :BufExplorer<CR>
+endif
+
+if !hasmapto('BufExplorer') && g:bufExplorerDisableDefaultKeyMapping == 0
+    noremap <script> <silent> <unique> <Leader>bt :ToggleBufExplorer<CR>
 endif
 
 if !hasmapto('BufExplorerHorizontalSplit') && g:bufExplorerDisableDefaultKeyMapping == 0

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1218,7 +1218,7 @@ if !hasmapto('BufExplorer') && g:bufExplorerDisableDefaultKeyMapping == 0
     nnoremap <script> <silent> <unique> <Leader>be :BufExplorer<CR>
 endif
 
-if !hasmapto('BufExplorer') && g:bufExplorerDisableDefaultKeyMapping == 0
+if !hasmapto('ToggleBufExplorer') && g:bufExplorerDisableDefaultKeyMapping == 0
     nnoremap <script> <silent> <unique> <Leader>bt :ToggleBufExplorer<CR>
 endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -346,6 +346,7 @@ endfunction
 " ToggleBufExplorer {{{2
 function! ToggleBufExplorer()
     if exists("s:running") && s:running == 1
+        call BufExplorer()
         call s:Close()
     else
         call BufExplorer()

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -57,6 +57,7 @@
 "               Or you can use
 "
 "                 ":BufExplorer"                - Opens BufExplorer
+"                 ":ToggleBufExplorer"          - Opens/Closes BufExplorer
 "                 ":BufExplorerHorizontalSplit" - Opens horizontally window BufExplorer
 "                 ":BufExplorerVerticalSplit"   - Opens vertically split window BufExplorer
 "
@@ -84,6 +85,7 @@ endif
 
 " Create commands {{{2
 command! BufExplorer :call BufExplorer()
+command! ToggleBufExplorer :call ToggleBufExplorer()
 command! BufExplorerHorizontalSplit :call BufExplorerHorizontalSplit()
 command! BufExplorerVerticalSplit :call BufExplorerVerticalSplit()
 
@@ -337,6 +339,15 @@ endfunction
 function! BufExplorerVerticalSplit()
     let s:splitMode = "vsp"
     execute "BufExplorer"
+endfunction
+
+" ToggleBufExplorer {{{2
+function! ToggleBufExplorer()
+    if exists("s:running") && s:running == 1
+        call s:Close()
+    else
+        call BufExplorer()
+    endif
 endfunction
 
 " BufExplorer {{{2


### PR DESCRIPTION
I added the following things to toggle the BufExplorer list on and off.
- the command `:ToggleBufExplorer`
- the map `<Leader>bt`, and 
- the function `ToggleBufExplorer()`

The function works by simply calling the `BufExplorer()` or `s:Close()` function, depending on the current state of BufExplorer. Now one can easily see which buffers are open (with a mapped function key, ideally), and then easily close the buffer list with the same key. 

I believe this pull request will satisfy the request in Issue #3.