### PR TITLE
Revert "bug fix"

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -116,8 +116,6 @@ let s:sort_by = ["number", "name", "fullpath", "mru", "extension"]
 let s:splitMode = ""
 let s:tabSpace = []
 let s:types = {"fullname": ':p', "path": ':p:h', "relativename": ':~:.', "relativepath": ':~:.:h', "shortname": ':t'}
-let s:altBufferOnEntry = ""
-let s:activeBufferOnEntry = ""
 
 " Setup the autocommands that handle the MRUList and other stuff. {{{2
 autocmd VimEnter * call s:Setup()
@@ -698,12 +696,6 @@ function! s:BuildBufferList()
             endif
         endif
 
-        if buf.attributes =~ "%"
-            let s:activeBufferOnEntry = matchstr(buf.attributes, '[0-9]\+')
-        elseif buf.attributes =~ "#"
-            let s:altBufferOnEntry =  matchstr(buf.attributes, '[0-9]\+')
-        endif
-
         let line = buf.attributes." "
 
         " Are we to split the path and file name?
@@ -937,8 +929,9 @@ function! s:Close()
     else
         " Since there are buffers left to switch to, switch to the previous and
         " then the current.
-        execute "keepjumps silent b ".s:altBufferOnEntry
-        execute "keepjumps silent b ".s:activeBufferOnEntry
+        for b in reverse(listed[0:1])
+            execute "keepjumps silent b ".b
+        endfor
     endif
 
     " Clear any messages.


### PR DESCRIPTION
Revert Pull Request #15, which was intended to address an issue resulting from spurious SessionLoadPost events in Vim causing the MRU list to be reset.  The plan now is to leave the code as was but to alert users to the problem in the documentation.