### PR TITLE
(Partially) Fixes: Erroneous listing of [BufExplorer] in buffer list

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -268,7 +268,7 @@ function! s:ShouldIgnore(buf)
     endif
 
     " Ignore the BufExplorer buffer.
-    if fnamemodify(bufname(a:buf), ":t") == s:name
+    if fnamemodify(bufname(a:buf), ":t") == s:BufExplorerName()
         return 1
     endif
 
@@ -344,22 +344,27 @@ endfunction
 
 " ToggleBufExplorer {{{2
 function! ToggleBufExplorer()
-    if exists("s:running") && s:running == 1
-        call BufExplorer()
+    if exists("s:running") && s:running == 1 && bufname(winbufnr(0)) == s:BufExplorerName()
         call s:Close()
     else
         call BufExplorer()
     endif
 endfunction
 
-" BufExplorer {{{2
-function! BufExplorer()
+" BufexplorerName {{{2
+function! s:BufExplorerName()
     let name = s:name
 
     if !has("win32")
         " On non-Windows boxes, escape the name so that is shows up correctly.
         let name = escape(name, "[]")
     endif
+    return name
+endfunction
+
+" BufExplorer {{{2
+function! BufExplorer()
+    let name = s:BufExplorerName()
 
     " Make sure there is only one explorer open at a time.
     if s:running == 1


### PR DESCRIPTION
This pull request partially fixes issue #28. Instead of always calling ```BufExplorer()``` - to ensure the buffer list is active - before calling ```s:Close()```, I put a check in the ```ToggleBufExplorer()``` function, based on the active window's current buffer name.

This should greatly reduce the frequency of the bad behavior described in the issue, but it can still be made to happen if you jump through the right hoops. One such scenario is:
```
:BufExplorer<CR>
:BufExplorer<CR>
q
:BufExplorer<CR>
```
It is the ```execute "drop" name``` statement in ```BufExplorer()``` that appears to be the issue, causing the **[BufExplorer]** buffer to be marked as listed.