### PR TITLE
Update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist.bat
 *.zip
 tags
+*.sw[a-p]

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ BufExplorer Plugin for Vim
 
 With bufexplorer, you can quickly and easily switch between buffers by using the one of the default public interfaces:
 
-  '\be' (normal open)  or
-  '\bt' (toggle open / close)  or
-  '\bs' (force horizontal split open)  or
-  '\bv' (force vertical split open)
+  '<Leader>be' (normal open)  or
+  '<Leader>bt' (toggle open / close)  or
+  '<Leader>bs' (force horizontal split open)  or
+  '<Leader>bv' (force vertical split open)
 
 Once the bufexplorer window is open you can use the normal movement keys (hjkl) to move around and then use <Enter> or <Left-Mouse-Click> to select the buffer you would like to open. If you would like to have the selected buffer opened in a new tab, simply press either <Shift-Enter> or 't'. Please note that when opening a buffer in a tab, that if the buffer is already in another tab, bufexplorer can switch to that tab automatically for you if you would like. More about that in the supplied VIM help.
 

--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -41,24 +41,24 @@ To install:
 USAGE                                                      *bufexplorer-usage*
 
 To start exploring in the current window, use: >
- \be   or   :BufExplorer   or   Your custom key mapping
+ <Leader>be   or   :BufExplorer   or   Your custom key mapping
 To toggle bufexplorer on or off in the current window, use: >
- \bt   or   :ToggleBufExplorer   or   Your custom key mapping
+ <Leader>bt   or   :ToggleBufExplorer   or   Your custom key mapping
 To start exploring in a newly split horizontal window, use: >
- \bs   or   :BufExplorerHorizontalSplit   or   Your custom key mapping
+ <Leader>bs   or   :BufExplorerHorizontalSplit   or   Your custom key mapping
 To start exploring in a newly split vertical window, use: >
- \bv   or   :BufExplorerVerticalSplit   or   Your custom key mapping
+ <Leader>bv   or   :BufExplorerVerticalSplit   or   Your custom key mapping
 
-If you would like to use something other than '\', you may simply change the
-leader (see |mapleader|).
+If you would like to use something other than the default leader key - '\' -
+you may simply change the leader (see |mapleader|).
 
-When \bs or \bv is issued, bufexplorer opens in either a horizonally or
-vertically split window.  By issusing either of these commands, the user is
-telling bufexplorer that they want to split the window and have bufexplorer
-show the buffer they are about to select (from the bufexplorer windows) in the
-newly split window.  When \be is issued, bufexplorer opens the bufexplorer
-contents in the current window and the buffer the user selects is opened in
-the current window.
+When <Leader>bs or <Leader>bv is issued, bufexplorer opens in either a
+horizontally or vertically split window.  By issusing either of these commands,
+the user is telling bufexplorer that they want to split the window and have
+bufexplorer show the buffer they are about to select (from the bufexplorer
+windows) in the newly split window.  When <Leader>be is issued, bufexplorer
+opens the bufexplorer contents in the current window and the buffer the user
+selects is opened in the current window.
 
 Note: If the current buffer is modified when bufexplorer started, the current
       window is always split and the new bufexplorer is displayed in that new
@@ -127,9 +127,9 @@ WINDOW LAYOUT                                       *bufexplorer-windowlayout*
 ===============================================================================
 CUSTOMIZATION                                       *bufexplorer-customization*
 
-If you do not like the default key mappings of \be, \bs, and \bv, you can
-override bufexplorer's default mappings by setting up something like the
-following in your vimrc file:
+If you do not like the default key mappings of <Leader>be, <Leader>bs, and 
+<Leader>bv, you can override bufexplorer's default mappings by setting up 
+something like the following in your vimrc file:
 
   nnoremap <silent> <F11> :BufExplorer<CR>
   nnoremap <silent> <s-F11> :ToggleBufExplorer<CR>
@@ -255,7 +255,7 @@ CHANGE LOG                                              *bufexplorer-changelog*
 
 7.4.8    January 27, 2015
     - Thanks to Marius Gedminas for fixing up the documentation and correcting
-      various typos. 
+      various typos.
 7.4.7    January 20, 2015
     - Thanks goes out to Phil Runninger for added the ability to toggle the
       bufexplorer list on and off using the :ToggleBufExplorer command, the


### PR DESCRIPTION
Documentation updated to refer to the leader key by '\<Leader\>', instead of its default value '\'. Fixes #34.