### PR TITLE
Add secondary check for listed buffers when closing.

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -914,6 +914,9 @@ endfunction
 function! s:Close()
     " Get only the listed buffers.
     let listed = filter(copy(s:MRUList), "buflisted(v:val)")
+    if len(listed) == 0
+        let listed = filter(range(1, bufnr('$')), "buflisted(v:val)")
+    endif
 
     " If we needed to split the main window, close the split one.
     if s:splitMode != "" && bufwinnr(s:originBuffer) != -1


### PR DESCRIPTION
Fixes #39...

If BufExplorer's MRUList is empty or has no listed buffers in it, create
an array of listed buffers from vim's buffer list instead.

Tested on console versions only:
* Windows, vim 7.4
* Mac OSX, neovim 0.1.1