### PR TITLE
Fix bug invalid tab range

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -822,7 +822,7 @@ function! s:SelectBuffer(...)
             " Was the tab found?
             if tabNbr == 0
                 " _bufNbr is not opened in any tabs. Open a new tab with the selected buffer in it.
-                execute "999tab split +buffer" . _bufNbr
+                execute "$tab split +buffer" . _bufNbr
                 " Workaround for the issue mentioned in UpdateTabBufData
                 call s:UpdateTabBufData(_bufNbr)
             else


### PR DESCRIPTION
How to replicate:

1. Try opening 2 buffers in a different tab.
2. Close tab 2.
3. Trigger BufExplorerHorizontalSplit on tab 1.
4. Press `t` on the buffer that has been previously closed.
5. Invalid Range error occurs.

This PR is fixing it.
But it's introducing another issue I don't know how to resolve that is: "Tab 1's BufExplorer window will open duplicate buffer".

@jlanzarotta 

But at least, it's fixing something. Previously, I couldn't open new tab using BufExplorer at all.