### PR TITLE
Backward-compatible fix for invalid tab range bug

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -826,7 +826,12 @@ function! s:SelectBuffer(...)
             " Was the tab found?
             if tabNbr == 0
                 " _bufNbr is not opened in any tabs. Open a new tab with the selected buffer in it.
-                execute "999tab split +buffer" . _bufNbr
+                if v:version > 704 || ( v:version == 704 && has('patch2237') )
+                  " new syntax for last tab as of 7.4.2237
+                  execute "$tab split +buffer" . _bufNbr
+                else
+                  execute "999tab split +buffer" . _bufNbr
+                endif
                 " Workaround for the issue mentioned in UpdateTabBufData
                 call s:UpdateTabBufData(_bufNbr)
             else


### PR DESCRIPTION
This PR has the same intention as #56, but is backward compatible with versions of Vim that do not support $tab. 

The problem is that "$tab" was introduced in 7.4.2237 as an alternative to 999tab. At some point, 999tab stop working. 


