### PR TITLE
Fix installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ This plugin can also be found at http://www.vim.org/scripts/script.php?script_id
 ### NeoBundle (https://github.com/Shougo/neobundle.vim)
 1. Add the following configuration to your `.vimrc`.
 
-        NeoBundle 'jlanzarotta/bufexplorer.vim'
+        NeoBundle 'jlanzarotta/bufexplorer'
 
 2. Install with `:NeoBundleInstall`.
 
 ### Plug (https://github.com/junegunn/vim-plug)
 1. Add the following configuration to your `.vimrc`.
 
-        Plug 'jlanzarotta/bufexplorer.vim'
+        Plug 'jlanzarotta/bufexplorer'
 
 2. Instal with `:PlugInstall`.
 


### PR DESCRIPTION
Fix installation command for Plug and NeoBundle as `bufexpolerer.vim` pointed to a private repository.