### PR TITLE
Add confirmation dialog to handle deletion of buffer with unsaved changes

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -966,21 +966,27 @@ function! s:RemoveBuffer(mode)
     let _bufNbr = str2nr(getline('.'))
 
     if getbufvar(_bufNbr, '&modified') == 1
-    if a:mode == "delete"
-        let answer = confirm('No write since last change for buffer '._bufNbr.'. Delete anyway?', "&Yes\n&No", 2)
-        if answer == 1
-            let mode = "force_delete"
-        else
+        " Calling confirm() requires Vim built with dialog option
+        if !has("dialog_con") && !has("dialog_gui")
+            call s:Error("Sorry, no write since last change for buffer "._bufNbr.", unable to delete")
             return
         endif
-    elseif a:mode == "wipe"
-        let answer = confirm('No write since last change for buffer '._bufNbr.'. Wipe anyway?', "&Yes\n&No", 2)
-        if answer == 1
-            let mode = "force_wipe"
-        else
-            return
+
+        if a:mode == "delete"
+            let answer = confirm('No write since last change for buffer '._bufNbr.'. Delete anyway?', "&Yes\n&No", 2)
+            if answer == 1
+                let mode = "force_delete"
+            else
+                return
+            endif
+        elseif a:mode == "wipe"
+            let answer = confirm('No write since last change for buffer '._bufNbr.'. Wipe anyway?', "&Yes\n&No", 2)
+            if answer == 1
+                let mode = "force_wipe"
+            else
+                return
+            endif
         endif
-    endif
 
     endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -972,14 +972,14 @@ function! s:RemoveBuffer(mode)
             return
         endif
 
-	let answer = confirm('No write since last change for buffer '._bufNbr.'. Delete anyway?', "&Yes\n&No", 2)
+        let answer = confirm('No write since last change for buffer '._bufNbr.'. Delete anyway?', "&Yes\n&No", 2)
 
         if a:mode == "delete" && answer == 1
-	    let mode = "force_delete"
-	elseif a:mode == "wipe" && answer == 1
-	    let mode = "force_wipe"
+            let mode = "force_delete"
+        elseif a:mode == "wipe" && answer == 1
+            let mode = "force_wipe"
         else
-                return
+            return
         endif
 
     endif

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -860,7 +860,7 @@ function! s:SelectBuffer(...)
                 execute s:GetWinNbr(tabNbr, _bufNbr) . "wincmd w"
             endif
             " Are we supposed to open the selected buffer in a split?
-        elseif (a:0 == 2) && (a:1 == "split")
+	elseif (a:0 == 2) && (a:1 == "split")
             if g:bufExplorerFindActive
                 call s:Close()
             endif
@@ -966,8 +966,8 @@ function! s:RemoveBuffer(mode)
     let _bufNbr = str2nr(getline('.'))
 
     if getbufvar(_bufNbr, '&modified') == 1 && a:mode != "force_delete"
-	call s:Error("Sorry, no write since last change for buffer "._bufNbr.", unable to delete")
-	return
+        call s:Error("Sorry, no write since last change for buffer "._bufNbr.", unable to delete")
+        return
     endif
 
     " Okay, everything is good, delete or wipe the buffer.
@@ -989,7 +989,7 @@ function! s:DeleteBuffer(buf, mode)
             execute "silent bwipe" a:buf
         elseif a:mode == "force_delete"
             execute "silent bdelete!" a:buf
-	else
+        else
             execute "silent bdelete" a:buf
         endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -972,20 +972,14 @@ function! s:RemoveBuffer(mode)
             return
         endif
 
-        if a:mode == "delete"
-            let answer = confirm('No write since last change for buffer '._bufNbr.'. Delete anyway?', "&Yes\n&No", 2)
-            if answer == 1
-                let mode = "force_delete"
-            else
+	let answer = confirm('No write since last change for buffer '._bufNbr.'. Delete anyway?', "&Yes\n&No", 2)
+
+        if a:mode == "delete" && answer == 1
+	    let mode = "force_delete"
+	elseif a:mode == "wipe" && answer == 1
+	    let mode = "force_wipe"
+        else
                 return
-            endif
-        elseif a:mode == "wipe"
-            let answer = confirm('No write since last change for buffer '._bufNbr.'. Wipe anyway?', "&Yes\n&No", 2)
-            if answer == 1
-                let mode = "force_wipe"
-            else
-                return
-            endif
         endif
 
     endif

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -965,17 +965,13 @@ function! s:RemoveBuffer(mode)
 
     let _bufNbr = str2nr(getline('.'))
 
-    if getbufvar(_bufNbr, '&modified') == 1
-
-        if a:mode != "force_delete"
-	    call s:Error("Sorry, no write since last change for buffer "._bufNbr.", unable to delete")
-	    return
-	endif
-        call s:DeleteBuffer(_bufNbr, a:mode)
-    else
-        " Okay, everything is good, delete or wipe the buffer.
-        call s:DeleteBuffer(_bufNbr, a:mode)
+    if getbufvar(_bufNbr, '&modified') == 1 && a:mode != "force_delete"
+	call s:Error("Sorry, no write since last change for buffer "._bufNbr.", unable to delete")
+	return
     endif
+
+    " Okay, everything is good, delete or wipe the buffer.
+    call s:DeleteBuffer(_bufNbr, a:mode)
 
     " Reactivate winmanager autocommand activity.
     if exists("b:displayMode") && b:displayMode == "winmanager"

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -860,7 +860,7 @@ function! s:SelectBuffer(...)
                 execute s:GetWinNbr(tabNbr, _bufNbr) . "wincmd w"
             endif
             " Are we supposed to open the selected buffer in a split?
-	elseif (a:0 == 2) && (a:1 == "split")
+        elseif (a:0 == 2) && (a:1 == "split")
             if g:bufExplorerFindActive
                 call s:Close()
             endif


### PR DESCRIPTION
Currently there is no option to force buffer deletion. This patch adds dialog which will ask user to confirm deletion if buffer has unsaved data and will call bd! or bw! if user confirms.