### PR TITLE
Allow deletion of last buffer.

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -957,12 +957,6 @@ function! s:RemoveBuffer(mode)
 
     let mode = a:mode
 
-    " Do not allow this buffer to be deleted if it is the last one.
-    if len(s:MRUList) == 1
-        call s:Error("Sorry, you are not allowed to delete the last buffer")
-        return
-    endif
-
     " These commands are to temporarily suspend the activity of winmanager.
     if exists("b:displayMode") && b:displayMode == "winmanager"
         call WinManagerSuspendAUs()


### PR DESCRIPTION
It's a useful feature to be able to delete all buffers.  It's very
convenient to delete buffers from within BufExplorer, but it's annoying
to be unable to delete the final buffer without exiting BufExplorer and
deleting the final buffer via ``:bwipeout`` or similar.

It's also difficult to accurately track buffers in ``s:MRUList`` under
all circumstances.  For example, after starting Vim and restoring a
session created with the ``:mksession`` command, buffers are added using
:badd, which BufExplorer currently doesn't track.  Attempting to delete
any of these buffers would previously fail with the message "Sorry, you
are not allowed to delete the last buffer".  To replicate this:

  # Launch vim with some non-existing files:
  vim one two three

  # Save a session file:
  :mksession session.vim

  # Exit Vim:
  :qa

  # Reload Vim and source the session:
  vim
  :source session.vim

  # Launch BufExplorer; attempts to delete any buffers will fail.

BufExplorer is already equipped to handle deletion of the last buffer,
as indeed it must be to reliably deal with the case of buffers being
deleted with :noautocmd, e.g.:

  # Open Vim with two non-existing files:
  vim one two

  # Delete the second buffer in Vim, without notifying BufExplorer:
  noautocmd bd 2

  # Launch BufExplorer; delete file "one", leaving no buffers.