### PR TITLE
delete [bufexplorer] appeared in jumplist

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -919,7 +919,7 @@ function! s:SelectBuffer(...)
             endif
 
             " Switch to the selected buffer.
-            execute "keepalt silent b!" _bufNbr
+            execute "keepjumps keepalt silent b!" _bufNbr
         endif
 
         " Make the buffer 'listed' again.


### PR DESCRIPTION
I found when using bufexplorer to switch a new buffer, a "[bufexplorer]" item will appear in the jumplist, and when jumping through ctrl-o and ctrl-i, will enter a blank screen. So I use ":keepjumps" to disable this annoying behavior.