### PR TITLE
Reset splitMode

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -392,12 +392,14 @@ endfunction
 function! BufExplorerHorizontalSplit()
     let s:splitMode = "sp"
     execute "BufExplorer"
+    let s:splitMode = ""
 endfunction
 
 " BufExplorerVerticalSplit {{{2
 function! BufExplorerVerticalSplit()
     let s:splitMode = "vsp"
     execute "BufExplorer"
+    let s:splitMode = ""
 endfunction
 
 " ToggleBufExplorer {{{2


### PR DESCRIPTION
If you use either split mode, you can no longer use the regular non-split mode. This is because the split mode set s:splitMode and that variable is never reset to "" to allow you run without split mode.
This change simply resets s:splitMode to "" after completing the split mode bufexplorer.