### PR TITLE
fix error when vim is in read-only mode

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -475,6 +475,7 @@ function! s:DisplayBufferList()
     " the buffer using CTRL-^.
     setlocal buftype=nofile
     setlocal modifiable
+    setlocal noreadonly
     setlocal noswapfile
     setlocal nowrap
 


### PR DESCRIPTION
If vim was started in read-only mode (`vim -R`), then opening bufexplorer triggers an error:
```
Error detected while processing function BufExplorer[49]..<SNR>49_DisplayBufferList:
line   16:W10: Warning: Changing a readonly file
```