### PR TITLE
Fix MRU sort order after loading vim session

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -138,6 +138,9 @@ let s:types = {"fullname": ':p', "path": ':p:h', "relativename": ':~:.', "relati
 " Setup the autocommands that handle the MRUList and other stuff. {{{2
 autocmd VimEnter * call s:Setup()
 
+" Reset MRUList and buffer->tab associations after loading a session. {{{2
+autocmd SessionLoadPost * call s:Reset()
+
 " Setup {{{2
 function! s:Setup()
     call s:Reset()
@@ -156,8 +159,9 @@ endfunction
 " Reset {{{2
 function! s:Reset()
     " Build initial MRUList. This makes sure all the files specified on the
-    " command line are picked up correctly.
-    let s:MRUList = range(1, bufnr('$'))
+    " command line are picked up correctly. Check buffers exist so this also
+    " works after wiping buffers and loading a session (e.g. sessionman.vim)
+    let s:MRUList = filter(range(1, bufnr('$')), 'bufexists(v:val)')
 
     " Initialize the association of buffers to tabs for any buffers
     " that have been created prior to now, e.g., files specified as


### PR DESCRIPTION
Loading a session which includes hidden or unloaded buffers breaks the
MRUList sort order in BufExplorer, because only the visible buffers are
added to the MRUList and the MRUCmp() function doesn't deal with buffer
numbers not found in the MRUList, which causes visible buffers included
in the MRUList to be listed after other buffers not yet in the MRUList.

Fix this by simply resetting the MRUList after loading a session so all
listed buffers are included.

To allow for wiping out buffers when switching between sessions, which
is done by sessionman.vim and possibly other plugins and scripts, also
filter MRUList when resetting to exclude buffers that no longer exist.