### PR TITLE
feat: add option g:bufExplorerShowTerminal to show terminal buffers or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-bufexplorer
-===========
+# bufexplorer
+
+---
 
 BufExplorer Plugin for Vim
 
@@ -13,28 +14,31 @@ With bufexplorer, you can quickly and easily switch between buffers by using the
 
 `\<Leader\>bv` force vertical split open
 
-
 Once the bufexplorer window is open you can use the normal movement keys (hjkl) to move around and then use `<Enter>` or `<Left-Mouse-Click>` to select the buffer you would like to open. If you would like to have the selected buffer opened in a new tab, simply press either `<Shift-Enter>` or `t`. Please note that when opening a buffer in a tab, that if the buffer is already in another tab, bufexplorer can switch to that tab automatically for you if you would like. More about that in the supplied VIM help.
 
 Bufexplorer also offers various options including:
+
 - Display the list of buffers in various sort orders including:
-    - Most Recently Used (MRU) which is the default
-    - Buffer number
-    - File name
-    - File extension
-    - Full file path name
+  - Most Recently Used (MRU) which is the default
+  - Buffer number
+  - File name
+  - File extension
+  - Full file path name
 - Delete buffer from list
 
 For more about options, sort orders, configuration options, etc. please see the supplied VIM help.
 
 ## vim.org
+
 This plugin can also be found at http://www.vim.org/scripts/script.php?script_id=42.
 
 ## Installation
+
 ### Manually
+
 1.  If you do not want to use one of the the bundle handlers, you can take the
     zip file from vim.org and unzip it and copy the plugin to your vimfiles\plugin
-    directory and the txt file to your vimfiles\doc directory.  If you do that,
+    directory and the txt file to your vimfiles\doc directory. If you do that,
     make sure you generate the help by executing
 
     `:helptag <your runtime directory>/doc`
@@ -43,32 +47,37 @@ This plugin can also be found at http://www.vim.org/scripts/script.php?script_id
     `:help bufexplorer`.
 
 ### Vundle (https://github.com/gmarik/Vundle.vim)
-1. Add the following configuration to your `.vimrc`.
+
+1.  Add the following configuration to your `.vimrc`.
 
         Plugin 'jlanzarotta/bufexplorer'
 
-2. Install with `:BundleInstall`.
+2.  Install with `:BundleInstall`.
 
 ### NeoBundle (https://github.com/Shougo/neobundle.vim)
-1. Add the following configuration to your `.vimrc`.
+
+1.  Add the following configuration to your `.vimrc`.
 
         NeoBundle 'jlanzarotta/bufexplorer'
 
-2. Install with `:NeoBundleInstall`.
+2.  Install with `:NeoBundleInstall`.
 
 ### Plug (https://github.com/junegunn/vim-plug)
-1. Add the following configuration to your `.vimrc`.
+
+1.  Add the following configuration to your `.vimrc`.
 
         Plug 'jlanzarotta/bufexplorer'
 
-2. Install with `:PlugInstall`.
+2.  Install with `:PlugInstall`.
 
 ### Pathogen
-1. Install with the following command.
+
+1.  Install with the following command.
 
         git clone https://github.com/jlanzarotta/bufexplorer.git ~/.vim/bundle/bufexplorer.vim
 
 ## License
+
 Copyright (c) 2001-2023, Jeff Lanzarotta
 
 All rights reserved.
@@ -76,14 +85,14 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
+- Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice, this
+- Redistributions in binary form must reproduce the above copyright notice, this
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
 
-* Neither the name of the {organization} nor the names of its
+- Neither the name of the {organization} nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -254,6 +254,12 @@ To control the size of the new vertical split window, use: >
   let g:bufExplorerSplitVertSize=0          " New split windows size set by Vim.
 The default is 0, so that the size is set by Vim.
 
+                                                   *g:bufExplorerShowTerminal*
+To control whether terminal buffers are displayed in BufExplorer, use: >
+  let g:bufExplorerShowTerminal=1           " Show terminal buffers.
+  let g:bufExplorerShowTerminal=0           " Don't show terminal buffers.
+The default is 1, to show the terminal buffers.
+
                                                    *g:bufExplorerVersionWarn*
 To control whether to warning about Vim version or not, use: >
   let g:bufExplorerVersionWarn=1       " Warn if version conflict.

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -625,6 +625,7 @@ function! s:GetHelpStatus()
     let ret .= ((g:bufExplorerOnlyOneTab == 0) ? "" : " | One tab/buffer")
     let ret .= ' | '.((g:bufExplorerShowRelativePath == 0) ? "Absolute" : "Relative")
     let ret .= ' '.((g:bufExplorerSplitOutPathName == 0) ? "Full" : "Split")." path"
+    let ret .= ((g:bufExplorerShowTerminal == 0) ? "" : " | Show terminal")
 
     return ret
 endfunction

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -709,6 +709,11 @@ function! s:GetBufferInfo(bufnr)
             let name = "[No Name]"
         endif
 
+        " Filter out term:// buffers if g:bufExplorerShowTerminal is 0
+        if !g:bufExplorerShowTerminal && name =~ '^term://'
+            continue
+        endif
+
         for [key, val] in items(s:types)
             let b[key] = fnamemodify(name, val)
         endfor
@@ -1356,6 +1361,7 @@ call s:Set("g:bufExplorerSplitOutPathName", 1)          " Split out path and fil
 call s:Set("g:bufExplorerSplitRight", &splitright)      " Should vertical splits be on the right or left of current window?
 call s:Set("g:bufExplorerSplitVertSize", 0)             " Height for a vertical split. If <=0, default Vim size is used.
 call s:Set("g:bufExplorerSplitHorzSize", 0)             " Height for a horizontal split. If <=0, default Vim size is used.
+call s:Set("g:bufExplorerShowTerminal", 1)              " Show terminal buffers?
 
 " Default key mapping {{{2
 if !hasmapto('BufExplorer') && g:bufExplorerDisableDefaultKeyMapping == 0

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -537,6 +537,8 @@ function! s:MapKeys()
     nnoremap <script> <silent> <nowait> <buffer> u             :call <SID>ToggleShowUnlisted()<CR>
     nnoremap <script> <silent> <nowait> <buffer> v             :call <SID>SelectBuffer("split", "vr")<CR>
     nnoremap <script> <silent> <nowait> <buffer> V             :call <SID>SelectBuffer("split", "vl")<CR>
+    nnoremap <script> <silent> <nowait> <buffer> H             :call <SID>ToggleShowTerminal()<CR>
+
 
     for k in ["G", "n", "N", "L", "M", "H"]
         execute "nnoremap <buffer> <silent>" k ":keepjumps normal!" k."<CR>"
@@ -1071,6 +1073,13 @@ function! s:Close()
 
     " Clear any messages.
     echo
+endfunction
+
+" ToggleShowTerminal {{{2
+function! s:ToggleShowTerminal()
+    let g:bufExplorerShowTerminal = !g:bufExplorerShowTerminal
+    call s:RebuildBufferList()
+    call s:UpdateHelpStatus()
 endfunction
 
 " ToggleSplitOutPathName {{{2


### PR DESCRIPTION
Thanks for you plugin, I've used this plugin for many years, but currently I met an annoying problem, I'm running jobs in terminal emulators, which were supported by Vim (since version 8.1) and Neovim. And the default behivor of bufexplorer will print all the buffers, including the terminal buffers, eg:

<img width="724" alt="image" src="https://github.com/user-attachments/assets/6e91cdf7-7072-48cf-8ca4-ea39ee00b6f0">


I don't want the bufexplorer to show the terminal buffers by default, so I added this option to show it or not.