### PR TITLE
Fix buffer sorting and display issues

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -687,7 +687,7 @@ function! s:GetBufferInfo(bufnr)
         let bufoutput = substitute(bufoutput."\n", '^.*\n\(\s*'.a:bufnr.'\>.\{-}\)\n.*', '\1', '')
     endif
 
-    let [all, allwidths, listedwidths] = [[], {}, {}]
+    let [all, allwidths, listedwidths] = [{}, {}, {}]
 
     for n in keys(s:types)
         let allwidths[n] = []
@@ -701,8 +701,9 @@ function! s:GetBufferInfo(bufnr)
         " Use first and last components after the split on '"', in case a
         " filename with an embedded '"' is present.
         let b = {"attributes": bits[0], "line": substitute(bits[-1], '\s*', '', '')}
+        let b._bufnr = str2nr(b.attributes)
 
-        let name = bufname(str2nr(b.attributes))
+        let name = bufname(b._bufnr)
         let b["hasNoName"] = empty(name)
         if b.hasNoName
             let name = "[No Name]"
@@ -721,7 +722,7 @@ function! s:GetBufferInfo(bufnr)
             let b.shortname = "<DIRECTORY>"
         endif
 
-        call add(all, b)
+        let all[b._bufnr] = b
 
         for n in keys(s:types)
             call add(allwidths[n], s:StringWidth(b[n]))
@@ -747,7 +748,7 @@ function! s:BuildBufferList()
     let lines = []
 
     " Loop through every buffer.
-    for buf in s:raw_buffer_listing
+    for buf in values(s:raw_buffer_listing)
         " Skip unlisted buffers if we are not to show them.
         if !g:bufExplorerShowUnlisted && buf.attributes =~ "u"
             " Skip unlisted buffers if we are not to show them.
@@ -982,7 +983,7 @@ function! s:DeleteBuffer(buf, mode)
         setlocal nomodifiable
 
         " Delete the buffer from the raw buffer list.
-        call filter(s:raw_buffer_listing, 'v:val.attributes !~ " '.a:buf.' "')
+        unlet s:raw_buffer_listing[a:buf]
     catch
         call s:Error(v:exception)
     endtry

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1141,11 +1141,6 @@ function! s:UpdateHelpStatus()
     setlocal nomodifiable
 endfunction
 
-" MRUCmp {{{2
-function! s:MRUCmp(line1, line2)
-    return index(s:MRUList, str2nr(a:line1)) - index(s:MRUList, str2nr(a:line2))
-endfunction
-
 " Key_name {{{2
 function! s:Key_name(line)
     let _bufnr = str2nr(a:line)
@@ -1169,6 +1164,17 @@ function! s:Key_extension(line)
     let extension = fnamemodify(buf.shortname, ':e')
     let key = [extension, buf.shortname, buf.fullname]
     return key
+endfunction
+
+" Key_mru {{{2
+function! s:Key_mru(line)
+    let _bufnr = str2nr(a:line)
+    let buf = s:raw_buffer_listing[_bufnr]
+    let pos = index(s:MRUList, _bufnr)
+    if pos < 0
+        let pos = 0
+    endif
+    return [printf('%9d', pos), buf.fullname]
 endfunction
 
 " SortByKeyFunc {{{2
@@ -1240,15 +1246,7 @@ function! s:SortListing()
     elseif g:bufExplorerSortBy == "extension"
         call s:SortByKeyFunc("<SID>Key_extension")
     elseif g:bufExplorerSortBy == "mru"
-        let l = getline(s:firstBufferLine, "$")
-
-        call sort(l, "<SID>MRUCmp")
-
-        if g:bufExplorerReverseSort
-            call reverse(l)
-        endif
-
-        call setline(s:firstBufferLine, l)
+        call s:SortByKeyFunc("<SID>Key_mru")
     endif
 endfunction
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -710,20 +710,11 @@ function! s:GetBufferInfo(bufnr)
         endif
 
         let b.isterminal = getbufvar(b._bufnr, '&buftype') == 'terminal'
-        " Filter out term:// buffers if g:bufExplorerShowTerminal is 0.
-        if !g:bufExplorerShowTerminal && b.isterminal
-            continue
-        endif
-
         for [key, val] in items(s:types)
             let b[key] = fnamemodify(name, val)
         endfor
 
         let b.isdir = getftype(b.fullname) == "dir"
-        if !g:bufExplorerShowDirectories && b.isdir
-            continue
-        endif
-
         if b.isdir
             let b.shortname = "<DIRECTORY>"
         endif
@@ -768,6 +759,16 @@ function! s:BuildBufferList()
 
         " Are we to show only buffer(s) for this tab?
         if g:bufExplorerShowTabBuffer && (!s:IsInCurrentTab(str2nr(buf.attributes)))
+            continue
+        endif
+
+        " Skip terminal buffers if we are not to show them.
+        if !g:bufExplorerShowTerminal && buf.isterminal
+            continue
+        endif
+
+        " Skip directory buffers if we are not to show them.
+        if !g:bufExplorerShowDirectories && buf.isdir
             continue
         endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1146,6 +1146,14 @@ function! s:MRUCmp(line1, line2)
     return index(s:MRUList, str2nr(a:line1)) - index(s:MRUList, str2nr(a:line2))
 endfunction
 
+" Key_name {{{2
+function! s:Key_name(line)
+    let _bufnr = str2nr(a:line)
+    let buf = s:raw_buffer_listing[_bufnr]
+    let key = [buf.shortname, buf.fullname]
+    return key
+endfunction
+
 " Key_fullpath {{{2
 function! s:Key_fullpath(line)
     let _bufnr = str2nr(a:line)
@@ -1217,14 +1225,7 @@ function! s:SortListing()
         " Easiest case.
         execute sort 'n'
     elseif g:bufExplorerSortBy == "name"
-        " Sort by full path first
-        execute sort 'ir /\zs\f\+\ze\s\+line/'
-
-        if g:bufExplorerSplitOutPathName
-            execute sort 'ir /\d.\{7}\zs\f\+\ze/'
-        else
-            execute sort 'ir /\zs[^\/\\]\+\ze\s*line/'
-        endif
+        call s:SortByKeyFunc("<SID>Key_name")
     elseif g:bufExplorerSortBy == "fullpath"
         call s:SortByKeyFunc("<SID>Key_fullpath")
     elseif g:bufExplorerSortBy == "extension"

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -805,7 +805,7 @@ function! s:BuildBufferList()
         let line = buf.attributes." "
 
         if exists("g:loaded_webdevicons")
-            let line .= WebDevIconsGetFileTypeSymbol(buf.shortname)
+            let line .= WebDevIconsGetFileTypeSymbol(buf.fullname, buf.isdir)
             let line .= " "
         endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -709,8 +709,9 @@ function! s:GetBufferInfo(bufnr)
             let name = "[No Name]"
         endif
 
+        let b.isterminal = getbufvar(b._bufnr, '&buftype') == 'terminal'
         " Filter out term:// buffers if g:bufExplorerShowTerminal is 0.
-        if !g:bufExplorerShowTerminal && name =~ '^term://'
+        if !g:bufExplorerShowTerminal && b.isterminal
             continue
         endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -718,7 +718,8 @@ function! s:GetBufferInfo(bufnr)
             let b[key] = fnamemodify(name, val)
         endfor
 
-        if getftype(b.fullname) == "dir" && g:bufExplorerShowDirectories == 1
+        let b.isdir = getftype(b.fullname) == "dir"
+        if b.isdir && g:bufExplorerShowDirectories == 1
             let b.shortname = "<DIRECTORY>"
         endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -812,12 +812,12 @@ function! s:BuildBufferList()
         " Are we to split the path and file name?
         if g:bufExplorerSplitOutPathName
             let type = (g:bufExplorerShowRelativePath) ? "relativepath" : "path"
-            let path = substitute( buf[type], $HOME."\\>", "~", "" )
+            let path = buf[type]
             let pad  = (g:bufExplorerShowUnlisted) ? s:allpads.shortname : s:listedpads.shortname
             let line .= buf.shortname." ".strpart(pad.path, s:StringWidth(buf.shortname))
         else
-            let type = (g:bufExplorerShowRelativePath) ? "relativename" : "fullname"
-            let path = substitute( buf[type], $HOME."\\>", "~", "" )
+            let type = (g:bufExplorerShowRelativePath) ? "relativename" : "homename"
+            let path = buf[type]
             let line .= path
         endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1141,6 +1141,13 @@ function! s:UpdateHelpStatus()
     setlocal nomodifiable
 endfunction
 
+" Key_number {{{2
+function! s:Key_number(line)
+    let _bufnr = str2nr(a:line)
+    let key = [printf('%9d', _bufnr)]
+    return key
+endfunction
+
 " Key_name {{{2
 function! s:Key_name(line)
     let _bufnr = str2nr(a:line)
@@ -1237,8 +1244,7 @@ function! s:SortListing()
     let sort = s:firstBufferLine.",$sort".((g:bufExplorerReverseSort == 1) ? "!": "")
 
     if g:bufExplorerSortBy == "number"
-        " Easiest case.
-        execute sort 'n'
+        call s:SortByKeyFunc("<SID>Key_number")
     elseif g:bufExplorerSortBy == "name"
         call s:SortByKeyFunc("<SID>Key_name")
     elseif g:bufExplorerSortBy == "fullpath"

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1162,6 +1162,15 @@ function! s:Key_fullpath(line)
     return key
 endfunction
 
+" Key_extension {{{2
+function! s:Key_extension(line)
+    let _bufnr = str2nr(a:line)
+    let buf = s:raw_buffer_listing[_bufnr]
+    let extension = fnamemodify(buf.shortname, ':e')
+    let key = [extension, buf.shortname, buf.fullname]
+    return key
+endfunction
+
 " SortByKeyFunc {{{2
 function! s:SortByKeyFunc(keyFunc)
     let keyedLines = []
@@ -1229,17 +1238,7 @@ function! s:SortListing()
     elseif g:bufExplorerSortBy == "fullpath"
         call s:SortByKeyFunc("<SID>Key_fullpath")
     elseif g:bufExplorerSortBy == "extension"
-        " Sort by full path...
-        execute sort 'ir /\zs\f\+\ze\s\+line/'
-
-        " Sort by name...
-        if g:bufExplorerSplitOutPathName
-            " Sort twice - first on the file name then on the path.
-            execute sort 'ir /\d.\{7}\zs\f\+\ze/'
-        endif
-
-        " Sort by extension.
-        execute sort 'ir /\.\zs\w\+\ze\s/'
+        call s:SortByKeyFunc("<SID>Key_extension")
     elseif g:bufExplorerSortBy == "mru"
         let l = getline(s:firstBufferLine, "$")
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -719,7 +719,11 @@ function! s:GetBufferInfo(bufnr)
         endfor
 
         let b.isdir = getftype(b.fullname) == "dir"
-        if b.isdir && g:bufExplorerShowDirectories == 1
+        if !g:bufExplorerShowDirectories && b.isdir
+            continue
+        endif
+
+        if b.isdir
             let b.shortname = "<DIRECTORY>"
         endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1241,19 +1241,7 @@ endfunction
 
 " SortListing {{{2
 function! s:SortListing()
-    let sort = s:firstBufferLine.",$sort".((g:bufExplorerReverseSort == 1) ? "!": "")
-
-    if g:bufExplorerSortBy == "number"
-        call s:SortByKeyFunc("<SID>Key_number")
-    elseif g:bufExplorerSortBy == "name"
-        call s:SortByKeyFunc("<SID>Key_name")
-    elseif g:bufExplorerSortBy == "fullpath"
-        call s:SortByKeyFunc("<SID>Key_fullpath")
-    elseif g:bufExplorerSortBy == "extension"
-        call s:SortByKeyFunc("<SID>Key_extension")
-    elseif g:bufExplorerSortBy == "mru"
-        call s:SortByKeyFunc("<SID>Key_mru")
-    endif
+    call s:SortByKeyFunc("<SID>Key_" . g:bufExplorerSortBy)
 endfunction
 
 " MRUListShow {{{2

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -740,8 +740,6 @@ function! s:GetBufferInfo(bufnr)
         " filename with an embedded '"' is present.
         let buf = {"attributes": bits[0], "line": substitute(bits[-1], '\s*', '', '')}
         let buf._bufnr = str2nr(buf.attributes)
-        call s:CalculateBufferDetails(buf)
-
         let all[buf._bufnr] = buf
     endfor
 
@@ -754,10 +752,19 @@ function! s:BuildBufferList()
 
     " Loop through every buffer.
     for buf in values(s:raw_buffer_listing)
+        " `buf.attributes` must exist, but we defer the expensive work of
+        " calculating other buffer details (e.g., `buf.fullname`) until we know
+        " the user wants to view this buffer.
+
         " Skip unlisted buffers if we are not to show them.
         if !g:bufExplorerShowUnlisted && buf.attributes =~ "u"
             " Skip unlisted buffers if we are not to show them.
             continue
+        endif
+
+        " Ensure buffer details are computed for this buffer.
+        if !has_key(buf, 'fullname')
+            call s:CalculateBufferDetails(buf)
         endif
 
         " Skip 'No Name' buffers if we are not to show them.


### PR DESCRIPTION
# Overview

This pull request addresses a few issues surrounding buffer sort order and buffer name displaying.  The initial motivation for these changes was to ensure that files and directories below a common directory would sort near each other when using the `fullpath` sort order.  With `fullpath`, the ordering should depend only on each buffer's full path name; historically, however, sorting has been a best-effort function of the displayed strings in the BufExplorer window, leading to some anomalies.

## Issues addressed by these changes

- Sorting by `fullname` now depends only on the buffer's absolute path using a new sorting mechanism. Other sort modes have been converted to use this mechanism as well.

- Display of directory buffers is now suppressed when `g:bufExplorerShowDirectories == 0` as described in the BufExplorer documentation.

- Path calculations for the elements in `s:types` have been normalized.  `fullpath` now has `simplify()` applied to normalize paths like `dir/../file`. Trailing path separators for directories have been removed. The shortname `<DIRECTORY>` for directories has been eliminated; instead, the directory's basename is used as is done for files (except for root directories, where the trailing path separator cannot be removed; a shortname of `.` is used for this case). A new element, `homepath`, has been added to `s.types`; this is `fullpath` shortened for paths in `$HOME` and without the trailing path separator.  Other displayable paths (`path`, `relativepath`, `relativename`) are similarly shortened for paths in `$HOME`.

- Textual substitution of `$HOME` -> `~` in paths has been eliminated.  This substitution could occur anywhere in the path, not just at the start, causing undesirable anomalies. Shortening for paths in `$HOME` is now done via `homename` and associated variables from `s:types`.

- If the devicons plugin is installed, a buffer's `buf.isdir` status has been added as a parameter passed to that plugin, allowing the plugin to supply a directory icon for buffer directories.

- Avoid calculating buffer details until they are needed for display.  Users who don't want to see unlisted buffers shouldn't have to pay for the expensive work of calculating buffer details for unlisted buffers, only to have that information ignored.  This resolves <https://github.com/jlanzarotta/bufexplorer/issues/20> ("bufexplorer is slow to open with many unlisted buffers").

# Below are some examples demonstrating the changes

Where "Before" and "After" examples are shown below, "Before" applies to BufExplorer 7.5.0 and "After" applies to this pull request.

## `fullpath` sorting

Start from the `bufexplorer/` source directory and invoke Vim as:

```sh
vim README.md doc/bufexplorer.txt ~/.bashrc doc/ . .. /rootfile / ~ /etc/hosts /etc
```

Then launch BufExplorer via `\be`.

- `Absolute Full path` view (uses `homename`):

  Before:

  ```
  " Press <F1> for Help
  " Sorted by fullpath | Locate buffer | One tab/buffer | Absolute Full path | Show terminal
  "=
    8       /                                                   line 0
   11       /etc/                                               line 0
   10       /etc/hosts                                          line 0
    7       /rootfile                                           line 0
    9       ~/                                                  line 0
    3       ~/.bashrc                                           line 0
    5       ~/projects/bufexplorer/                             line 0
    6       ~/projects/bufexplorer/../                          line 0
    4       ~/projects/bufexplorer/doc/                         line 0
    2       ~/projects/bufexplorer/doc/bufexplorer.txt          line 0
    1 %a    ~/projects/bufexplorer/README.md                    line 16
  ```

  After:

  ```
  " Press <F1> for Help
  " Sorted by fullpath | Locate buffer | One tab/buffer | Absolute Full path | Show terminal
  "=
    8       /                                          line 0
   11       /etc                                       line 0
   10       /etc/hosts                                 line 0
    9       ~                                          line 0
    3       ~/.bashrc                                  line 0
    6       ~/projects                                 line 0
    5       ~/projects/bufexplorer                     line 0
    4       ~/projects/bufexplorer/doc                 line 0
    2       ~/projects/bufexplorer/doc/bufexplorer.txt line 0
    1 %a    ~/projects/bufexplorer/README.md           line 16
    7       /rootfile                                  line 0
  ```

- `Relative Full path` view (uses `relativename`):

  Before:

  ```
  " Press <F1> for Help
  " Sorted by fullpath | Locate buffer | One tab/buffer | Relative Full path | Show terminal
  "=
    6       ..                     line 0
    8       /                      line 0
   11       /etc                   line 0
   10       /etc/hosts             line 0
    7       /rootfile              line 0
    4       doc                    line 0
    2       doc/bufexplorer.txt    line 0
    1 %a    README.md              line 16
    9       ~                      line 0
    3       ~/.bashrc              line 0
    5       ~/projects/bufexplorer line 0
  ```

  After:

  ```
  " Press <F1> for Help
  " Sorted by fullpath | Locate buffer | One tab/buffer | Relative Full path | Show terminal
  "=
    8       /                   line 0
   11       /etc                line 0
   10       /etc/hosts          line 0
    9       ~                   line 0
    3       ~/.bashrc           line 0
    6       ~/projects          line 0
    5       .                   line 0
    4       doc                 line 0
    2       doc/bufexplorer.txt line 0
    1 %a    README.md           line 16
    7       /rootfile           line 0
  ```

- `Absolute Split path` view (uses `shortname` + `path`):

  Before:

  ```
  " Press <F1> for Help
  " Sorted by fullpath | Locate buffer | One tab/buffer | Absolute Split path | Show terminal
  "=
    8       <DIRECTORY>     /                                   line 0
    7       rootfile        /                                   line 0
   11       <DIRECTORY>     /etc                                line 0
   10       hosts           /etc                                line 0
    9       <DIRECTORY>     ~                                   line 0
    3       .bashrc         ~                                   line 0
    5       <DIRECTORY>     ~/projects/bufexplorer              line 0
    1 %a    README.md       ~/projects/bufexplorer              line 16
    6       <DIRECTORY>     ~/projects/bufexplorer/..           line 0
    4       <DIRECTORY>     ~/projects/bufexplorer/doc          line 0
    2       bufexplorer.txt ~/projects/bufexplorer/doc          line 0
  ```

  After:

  ```
  " Press <F1> for Help
  " Sorted by fullpath | Locate buffer | One tab/buffer | Absolute Split path | Show terminal
  "=
    8       .               /                          line 0
   11       etc             /                          line 0
   10       hosts           /etc                       line 0
    9       mike            /home                      line 0
    3       .bashrc         ~                          line 0
    6       projects        ~                          line 0
    5       bufexplorer     ~/projects                 line 0
    4       doc             ~/projects/bufexplorer     line 0
    2       bufexplorer.txt ~/projects/bufexplorer/doc line 0
    1 %a    README.md       ~/projects/bufexplorer     line 16
    7       rootfile        /                          line 0
  ```

- `Relative Split path` view (uses `shortname` + `relativepath`):

  Before:

  ```
  " Press <F1> for Help
  " Sorted by fullpath | Locate buffer | One tab/buffer | Relative Split path | Show terminal
  "=
    4       <DIRECTORY>     .          line 0
    6       <DIRECTORY>     .          line 0
    9       <DIRECTORY>     .          line 0
    1 %a    README.md       .          line 16
    8       <DIRECTORY>     /          line 0
   11       <DIRECTORY>     /          line 0
    7       rootfile        /          line 0
   10       hosts           /etc       line 0
    2       bufexplorer.txt doc        line 0
    3       .bashrc         ~          line 0
    5       <DIRECTORY>     ~/projects line 0
  ```

  After:

  ```
  " Press <F1> for Help
  " Sorted by fullpath | Locate buffer | One tab/buffer | Relative Split path | Show terminal
  "=
    8       .               /          line 0
   11       etc             /          line 0
   10       hosts           /etc       line 0
    9       mike            /home      line 0
    3       .bashrc         ~          line 0
    6       projects        ~          line 0
    5       bufexplorer     ~/projects line 0
    4       doc             .          line 0
    2       bufexplorer.txt doc        line 0
    1 %a    README.md       .          line 16
    7       rootfile        /          line 0
  ```

## Substitution of `~` with `$HOME`

To demonstrate the problem of substituting `~` with `$HOME`, create a test directory and launch Vim as follows:

```sh
mkdir -p tmp$HOME
vim tmp$HOME/file.txt
```

Then invoke BufExplorer via `\be`.  Notice that the file's path was previously incorrectly shortened to `tmp~`:

- Before:

  ```
  " Press <F1> for Help
  " Sorted by mru | Locate buffer | One tab/buffer | Relative Split path | Show terminal
  "=
    1 %a    file.txt tmp~          line 1
  ```

- After:

  ```
  " Press <F1> for Help
  " Sorted by mru | Locate buffer | One tab/buffer | Relative Split path | Show terminal
  "=
    1 %a    file.txt tmp/home/mike line 1
  ```

Also, because of the last-minute nature of the textual substitution of `~` with `$HOME`, minimum column width calculation could have overestimated how many columns were necessary.  This can be seen in the previous `Absolute Full path` example above, e.g.:

  Before:

  ```
    2       ~/projects/bufexplorer/doc/bufexplorer.txt          line 0
  ```

  After:

  ```
    2       ~/projects/bufexplorer/doc/bufexplorer.txt line 0
  ```

## Speed when ignoring unlisted buffers

To demonstrate speed improvements in the presence of many unlisted buffers, create a test directory with many small files:

```sh
mkdir -p tmp
for i in tmp/file{1..5000}.txt; do echo text > $i; done
```

Invoke Vim and search for `text` in these files:

```sh
vim
```
```vim
:grep text tmp/file*.txt
```

Use Vim's profiling feature to measure timing:

```vim
:profile start profile.log | profile func * | profile file *
```

Then invoke BufExplorer via `\be`.  By default, unlisted buffers are not displayed.

Now stop profiling and exit Vim:

```vim
:profile pause | noautocmd qall
```

`profile.log` will have timing measurements.  Excerpts below focus on the total time of the `BufExplorer()` function.

- Before:

  ```
  FUNCTIONS SORTED ON TOTAL TIME
  count     total (s)      self (s)  function
      1   0.604716401   0.002036093  BufExplorer()
  ```

- After:

  ```
  FUNCTIONS SORTED ON TOTAL TIME
  count     total (s)      self (s)  function
      1   0.174561318   0.001017237  BufExplorer()
  ```

Total BufExplorer time went down from 605 ms to 175 ms when ignoring unlisted buffers.

To test with unlisted buffers active, relaunch Vim, launch BufExplorer with `\be`, press `u` to display unlisted buffers, then quit BufExplorer via `q`.

Now repeat the `:grep` measurements as above:

```
:grep text tmp/file*.txt
:profile start profile.log | profile func * | profile file *
\be
:profile pause | noautocmd qall
```

- Before:

  ```
  FUNCTIONS SORTED ON TOTAL TIME
  count     total (s)      self (s)  function
      1   0.824951205   0.002819013  BufExplorer()
  ```

- After:

  ```
  FUNCTIONS SORTED ON TOTAL TIME
  count     total (s)      self (s)  function
      1   0.776613797   0.001670610  BufExplorer()
  ```
