### PR TITLE
Improve buffer MRU tracking algorithm

### DIFF
--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -173,6 +173,17 @@ The default is to be taken to the active window.
 When a buffer is selected, the functions specified either singly or as a list
 will be called.
 
+                                                      *g:bufExplorerOnlyOneTab*
+To control whether a buffer should be shown on any tab where it has ever been
+used or only on the most-recently-used (MRU) tab (i.e., the tab where the buffer
+was most recently used), use: >
+  let g:bufExplorerOnlyOneTab=0        " Show in all tabs where buffer was used.
+  let g:bufExplorerOnlyOneTab=1        " Show buffer only in MRU tab.
+The default is `1` (show a buffer only on the MRU tab).
+This setting applies only when |g:bufExplorerShowTabBuffer| is true (i.e., when
+BufExplorer shows only those buffers used in the current tab instead of showing
+all buffers).
+
                                                      *g:bufExplorerReverseSort*
 To control whether to sort the buffer in reverse order or not, use: >
   let g:bufExplorerReverseSort=0       " Do not sort in reverse order.

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1505,10 +1505,7 @@ endfunction
 function! s:Key_mru(line)
     let _bufnr = str2nr(a:line)
     let buf = s:raw_buffer_listing[_bufnr]
-    let pos = index(s:MRUList, _bufnr)
-    if pos < 0
-        let pos = 0
-    endif
+    let pos = s:MRUOrderForBuf(_bufnr)
     return [printf('%9d', pos), buf.fullname]
 endfunction
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1090,8 +1090,8 @@ function! s:BuildBufferList()
             continue
         endif
 
-        " Are we to show only buffer(s) for this tab?
-        if g:bufExplorerShowTabBuffer && (!s:IsInCurrentTab(str2nr(buf.attributes)))
+        " Should we show this buffer in this tab?
+        if !s:MRUTabShouldShowBuf(s:tabIdAtLaunch, buf._bufnr)
             continue
         endif
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -808,6 +808,11 @@ function! s:BuildBufferList()
 
     let lines = s:MakeLines(table)
     call setline(s:firstBufferLine, lines)
+    let firstMissingLine = s:firstBufferLine + len(lines)
+    if line('$') >= firstMissingLine
+        " Clear excess lines starting with `firstMissingLine`.
+        execute "silent keepjumps ".firstMissingLine.',$d _'
+    endif
     call s:SortListing()
 endfunction
 
@@ -1095,7 +1100,7 @@ endfunction
 " ToggleShowTabBuffer {{{2
 function! s:ToggleShowTabBuffer()
     let g:bufExplorerShowTabBuffer = !g:bufExplorerShowTabBuffer
-    call s:RebuildBufferList(g:bufExplorerShowTabBuffer)
+    call s:RebuildBufferList()
     call s:UpdateHelpStatus()
 endfunction
 
@@ -1109,7 +1114,7 @@ endfunction
 " ToggleShowUnlisted {{{2
 function! s:ToggleShowUnlisted()
     let g:bufExplorerShowUnlisted = !g:bufExplorerShowUnlisted
-    let num_bufs = s:RebuildBufferList(g:bufExplorerShowUnlisted == 0)
+    let num_bufs = s:RebuildBufferList()
     call s:UpdateHelpStatus()
 endfunction
 
@@ -1120,15 +1125,10 @@ function! s:ToggleFindActive()
 endfunction
 
 " RebuildBufferList {{{2
-function! s:RebuildBufferList(...)
+function! s:RebuildBufferList()
     setlocal modifiable
 
     let curPos = getpos('.')
-
-    if a:0 && a:000[0] && (line('$') >= s:firstBufferLine)
-        " Clear the list first.
-        execute "silent keepjumps ".s:firstBufferLine.',$d _'
-    endif
 
     let num_bufs = s:BuildBufferList()
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1321,6 +1321,21 @@ let g:BufExplorer_title = "\[Buf\ List\]"
 call s:Set("g:bufExplorerResize", 1)
 call s:Set("g:bufExplorerMaxHeight", 25) " Handles dynamic resizing of the window.
 
+" Evaluate a Vimscript expression in the context of this file.
+" This enables debugging of script-local variables and functions from outside
+" the plugin, e.g.:
+"   :echo BufExplorer_eval('s:bufMru')
+function! BufExplorer_eval(expr)
+    return eval(a:expr)
+endfunction
+
+" Execute a Vimscript statement in the context of this file.
+" This enables setting script-local variables from outside the plugin, e.g.:
+"   :call BufExplorer_execute('let s:bufMru = s:MRUNew(0)')
+function! BufExplorer_execute(statement)
+    execute a:statement
+endfunction
+
 " function! to start display. Set the mode to 'winmanager' for this buffer.
 " This is to figure out how this plugin was called. In a standalone fashion
 " or by winmanager.

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1365,11 +1365,8 @@ endfunction
 
 " Close {{{2
 function! s:Close()
-    " Get only the listed buffers associated with the current tab.
-    let listed = filter(copy(s:MRUList), "s:ListedAndCurrentTab(v:val)")
-    if len(listed) == 0
-        let listed = filter(range(1, bufnr('$')), "s:ListedAndCurrentTab(v:val)")
-    endif
+    " Get only the listed buffers associated with the current tab (up to 2).
+    let listed = s:MRUListedBuffersForTab(s:tabIdAtLaunch, 2)
 
     " If we needed to split the main window, close the split one.
     if s:didSplit

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -139,13 +139,8 @@ let s:types = ["fullname", "homename", "path", "relativename", "relativepath", "
 " Setup the autocommands that handle the MRUList and other stuff. {{{2
 autocmd VimEnter * call s:Setup()
 
-" Reset MRUList and buffer->tab associations after loading a session. {{{2
-autocmd SessionLoadPost * call s:Reset()
-
 " Setup {{{2
 function! s:Setup()
-    call s:Reset()
-
     " Now that the MRUList is created, add the other autocmds.
     augroup BufExplorer
         autocmd!

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -830,7 +830,7 @@ function! s:CreateHelp()
         call add(header, '" <shift-enter> or t : open buffer in another tab')
         call add(header, '" a : toggle find active buffer')
         call add(header, '" b : Fast buffer switching with b<any bufnum>')
-        call add(header, '" B : toggle if to save/use recent tab or not')
+        call add(header, '" B : toggle showing buffers only on their MRU tabs')
         call add(header, '" d : delete buffer')
         call add(header, '" D : wipe buffer')
         call add(header, '" F : open buffer in another window above the current')
@@ -841,7 +841,7 @@ function! s:CreateHelp()
         call add(header, '" R : toggle showing relative or full paths')
         call add(header, '" s : cycle thru "sort by" fields '.string(s:sort_by).'')
         call add(header, '" S : reverse cycle thru "sort by" fields')
-        call add(header, '" T : toggle if to show only buffers for this tab or not')
+        call add(header, '" T : toggle showing all buffers/only buffers used on this tab')
         call add(header, '" u : toggle showing unlisted buffers')
         call add(header, '" V : open buffer in another window on the left of the current')
         call add(header, '" v : open buffer in another window on the right of the current')
@@ -1558,7 +1558,7 @@ call s:Set("g:bufExplorerDisableDefaultKeyMapping", 0)  " Do not disable default
 call s:Set("g:bufExplorerDefaultHelp", 1)               " Show default help?
 call s:Set("g:bufExplorerDetailedHelp", 0)              " Show detailed help?
 call s:Set("g:bufExplorerFindActive", 1)                " When selecting an active buffer, take you to the window where it is active?
-call s:Set("g:bufExplorerOnlyOneTab", 1)                " If ShowTabBuffer = 1, only store the most recent tab for this buffer.
+call s:Set("g:bufExplorerOnlyOneTab", 1)                " Show buffer only on MRU tab? (Applies when `g:bufExplorerShowTabBuffer` is true.)
 call s:Set("g:bufExplorerReverseSort", 0)               " Sort in reverse order by default?
 call s:Set("g:bufExplorerShowDirectories", 1)           " (Dir's are added by commands like ':e .')
 call s:Set("g:bufExplorerShowRelativePath", 0)          " Show listings with relative or absolute paths?

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -185,6 +185,25 @@ function! s:CatalogBuffers()
     silent execute 'normal! ' . ct . 'gt'
 endfunction
 
+" AssignTabId {{{2
+" Assign a `tabId` to the given tab.
+function! s:AssignTabId(tabNbr)
+    " Create a unique `tabId` based on the current time and an incrementing
+    " counter value that helps ensure uniqueness.
+    let tabId = reltimestr(reltime()) . ':' . s:tabIdCounter
+    call settabvar(a:tabNbr, 'bufexp_tabId', tabId)
+    let s:tabIdCounter = (s:tabIdCounter + 1) % 1000000000
+    return tabId
+endfunction
+
+let s:tabIdCounter = 0
+
+" GetTabId {{{2
+" Retrieve the `tabId` for the given tab (or '' if the tab has no `tabId`).
+function! s:GetTabId(tabNbr)
+    return gettabvar(a:tabNbr, 'bufexp_tabId', '')
+endfunction
+
 " AssociatedTab {{{2
 " Return the number of the tab associated with the specified buffer. If the
 " buffer is associated with more than one tab, the first one found is

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -514,6 +514,7 @@ function! s:MapKeys()
     nnoremap <script> <silent> <nowait> <buffer> <s-cr>        :call <SID>SelectBuffer("tab")<CR>
     nnoremap <script> <silent> <nowait> <buffer> a             :call <SID>ToggleFindActive()<CR>
     nnoremap <script> <silent> <nowait> <buffer> b             :call <SID>SelectBuffer("ask")<CR>
+    nnoremap <script> <silent> <nowait> <buffer> B             :call <SID>ToggleOnlyOneTab()<CR>
     nnoremap <script> <silent> <nowait> <buffer> d             :call <SID>RemoveBuffer("delete")<CR>
     xnoremap <script> <silent> <nowait> <buffer> d             :call <SID>RemoveBuffer("delete")<CR>
     nnoremap <script> <silent> <nowait> <buffer> D             :call <SID>RemoveBuffer("wipe")<CR>

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -833,7 +833,6 @@ function! s:MapKeys()
     xnoremap <script> <silent> <nowait> <buffer> D             :call <SID>RemoveBuffer("wipe")<CR>
     nnoremap <script> <silent> <nowait> <buffer> f             :call <SID>SelectBuffer("split", "sb")<CR>
     nnoremap <script> <silent> <nowait> <buffer> F             :call <SID>SelectBuffer("split", "st")<CR>
-    nnoremap <script> <silent> <nowait> <buffer> m             :call <SID>MRUListShow()<CR>
     nnoremap <script> <silent> <nowait> <buffer> o             :call <SID>SelectBuffer()<CR>
     nnoremap <script> <silent> <nowait> <buffer> p             :call <SID>ToggleSplitOutPathName()<CR>
     nnoremap <script> <silent> <nowait> <buffer> q             :call <SID>Close()<CR>

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -129,6 +129,8 @@ endfunction
 let s:MRU_Exclude_List = ["[BufExplorer]","__MRU_Files__","[Buf\ List]"]
 let s:name = '[BufExplorer]'
 let s:originBuffer = 0
+" Buffer number of the BufExplorer window.
+let s:bufExplorerBuffer = 0
 let s:running = 0
 let s:sort_by = ["number", "name", "fullpath", "mru", "extension"]
 let s:splitMode = ""
@@ -650,6 +652,9 @@ function! BufExplorer()
         execute "silent keepjumps hide edit".name
     endif
 
+    " Record BufExplorer's buffer number.
+    let s:bufExplorerBuffer = bufnr('%')
+
     call s:DisplayBufferList()
 
     " Position the cursor in the newly displayed list on the line representing
@@ -942,6 +947,11 @@ function! s:BuildBufferList()
         " `buf.attributes` must exist, but we defer the expensive work of
         " calculating other buffer details (e.g., `buf.fullname`) until we know
         " the user wants to view this buffer.
+
+        " Skip BufExplorer's buffer.
+        if buf._bufnr == s:bufExplorerBuffer
+            continue
+        endif
 
         " Skip unlisted buffers if we are not to show them.
         if !g:bufExplorerShowUnlisted && buf.attributes =~ "u"

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -136,20 +136,14 @@ let s:didSplit = 0
 let s:types = ["fullname", "homename", "path", "relativename", "relativepath", "shortname"]
 
 " Setup the autocommands that handle stuff. {{{2
-autocmd VimEnter * call s:Setup()
-
-" Setup {{{2
-function! s:Setup()
-    " Add the other autocmds.
-    augroup BufExplorer
-        autocmd!
-        autocmd WinEnter        * call s:DoWinEnter()
-        autocmd BufEnter        * call s:DoBufEnter()
-        autocmd BufDelete       * call s:DoBufDelete()
-        autocmd BufWinEnter \[BufExplorer\] call s:Initialize()
-        autocmd BufWinLeave \[BufExplorer\] call s:Cleanup()
-    augroup END
-endfunction
+augroup BufExplorer
+    autocmd!
+    autocmd WinEnter        * call s:DoWinEnter()
+    autocmd BufEnter        * call s:DoBufEnter()
+    autocmd BufDelete       * call s:DoBufDelete()
+    autocmd BufWinEnter \[BufExplorer\] call s:Initialize()
+    autocmd BufWinLeave \[BufExplorer\] call s:Cleanup()
+augroup END
 
 " AssignTabId {{{2
 " Assign a `tabId` to the given tab.


### PR DESCRIPTION
# Overview

This pull request provides a new MRU buffer tracking algorithm to:

- Fix issue #8 "Bufexplorer MRU sort doesn't work properly if using restore_session.vim".

- Fix issue #87 "Bufexplorer interferes with the startinsert! command".

- Treat unlisted buffers as least-recently-used instead of most-recently-used in the MRU sort order.

- Remove the now-unneeded status indicator "One tab/buffer" in the BufExplorer status line; also remove the associated undocumented variable `g:bufExplorerOnlyOneTab`.

- Replace the undocumented `m` key (intended for debugging MRU logic) with the `BufExplorer_eval()` and `BufExplorer_execute()` general debugging features.

- Improve speed of MRU tracking.

# Details

- For demonstration purposes, create a temporary directory for testing and create a few test files:

  ```
  mkdir testing
  cd testing
  touch file{1..500}.txt
  printf '%s:1:1\n' file{1..500}.txt > 500files.out
  printf '%s:1:1\n' file{1..9}.txt > 9files.out
  ```

  `500files.out` and `9files.out` have simulated compiler output suitable for use with `:cgetfile`; for example, `9files.out` is:

  ```
  file1.txt:1:1
  file2.txt:1:1
  file3.txt:1:1
  file4.txt:1:1
  file5.txt:1:1
  file6.txt:1:1
  file7.txt:1:1
  file8.txt:1:1
  file9.txt:1:1
  ```

- MRU tracking is now done only on-demand as buffers come and go, so there is no need to track buffers at plugin startup or session-load time.  This resolves two issues:

  - Issue #8 "Bufexplorer MRU sort doesn't work properly if using restore_session.vim" was caused by resetting the MRU list via `s:Reset()` after a session is loaded.  Removing the `SessionLoadPost` autocmd that invokes this function resolves this issue.

  - Issue #87 "Bufexplorer interferes with the startinsert! command" was caused, as correctly diagnosed by the original poster, by the use of `:normal!` in the `s:CatalogBuffers()` function:

    ```vim
    silent execute 'normal! ' . tab . 'gt'
    ```

    `s:CatalogBuffers()` is no longer called at startup, resolving this issue.

- Unlisted buffers (as created by `:grep` or `:cgetfile`, for example) are now treated as least-recently-used instead of most-recently-used in the MRU sort order.  For example, launch Vim and run these commands:

  ```vim
  :edit file1.txt
  :edit file2.txt
  :cgetfile 9files.out
  ```

  Then launch BufExplorer and press `u` to view unlisted buffers.

  - Using BufExplorer 7.6.0, this results in:

    ```
    " Press <F1> for Help
    " Sorted by mru | Locate buffer | Show unlisted | One tab/buffer | Absolute Split path | Show terminal
    "=
      2 %a    file2.txt ~/testing line 1
      3u      file3.txt ~/testing line 0
      4u      file4.txt ~/testing line 0
      5u      file5.txt ~/testing line 0
      6u      file6.txt ~/testing line 0
      7u      file7.txt ~/testing line 0
      8u      file8.txt ~/testing line 0
      9u      file9.txt ~/testing line 0
      1 #     file1.txt ~/testing line 1
    ```

    Note that the unlisted buffers 3-9 (which have never been opened) are found between buffers 1 and 2 (which were used most recently).

  - Using the `mru` branch, unlisted buffers are shown last:

    ```
    " Press <F1> for Help
    " Sorted by mru | Locate buffer | Show unlisted | Absolute Split path | Show terminal
    "=
      2 %a    file2.txt ~/testing line 1
      1 #     file1.txt ~/testing line 1
      3u      file3.txt ~/testing line 0
      4u      file4.txt ~/testing line 0
      5u      file5.txt ~/testing line 0
      6u      file6.txt ~/testing line 0
      7u      file7.txt ~/testing line 0
      8u      file8.txt ~/testing line 0
      9u      file9.txt ~/testing line 0
    ```

- The undocumented variable `g:bufExplorerOnlyOneTab` has been removed. Commit 3c0b11f3dd2eb05bb19b4db8e078fe96ff015e61 (2017-09-18) removed the `B` key that permitted toggling this variable (via the `s:ToggleOnlyOneTab()` function).  The variable controlled whether MRU data for a buffer would be gathered globally or on a per-tab basis (and defaulting to per-tab collection).  In the new MRU algorithm, this control is not needed because MRU information is gathered and kept independently of whether buffers will be subsequently displayed globally or on a per-tab basis. As a result, the now-unneeded status indicator "One tab/buffer" has been removed, saving space in the BufExplorer status line.

- The undocumented `m` key (intended for debugging MRU logic) has been removed and replace with more general `BufExplorer_eval()` and `BufExplorer_execute()` debugging features.  These can be used to view or modify script-local variables and invoke script-local functions from outside the plugin.  For example:

  - To display the MRU data structure `s:bufMru`:

        :echo BufExplorer_eval('s:bufMru')

  - To use `s:MRUGetItems()` to display buffer numbers from this structure in MRU-order:

        :echo BufExplorer_eval('s:MRUGetItems(s:bufMru,0)')

  - To re-initialize `s:bufMru`:

        :call BufExplorer_execute('let s:bufMru = s:MRUNew(0)')

- The new MRU algorithm gathers buffer MRU data using a doubly linked list to avoid linear searching through arrays, and it defers display-related computations until BufExplorer has been invoked, improving MRU data collection speed.  To demonstrate, launch Vim via:

  ```
  vim file*.txt
  ```

  First, visit all files in the argument list to ensure they've all been opened. The repeat the operation while profiling and view `profile.log`:

  ```vim
  :silent argdo e

  :profile start profile.log | profile func * | profile file *
  :silent argdo e
  :profile pause | noautocmd qall
  ```

  - Using BufExplorer 7.6.0, this results in:

    ```
    FUNCTIONS SORTED ON TOTAL TIME
    count     total (s)      self (s)  function
     1000   0.164370828   0.005045087  <SNR>2_ActivateBuffer()
     1000   0.130688003   0.006358159  <SNR>2_MRUPush()
     1000   0.112038402                <SNR>2_MRUPop()
     1000   0.029297798   0.025142784  <SNR>7_Highlight_Matching_Pair()
     1000   0.028637738   0.010886118  <SNR>2_UpdateTabBufData()
     1000   0.020331084                <SNR>8_LocalBrowse()
     1000   0.012291442                <SNR>2_ShouldIgnore()
     1000   0.011743064                <SNR>2_RemoveBufFromOtherTabs()
     1500   0.006926867                <SNR>7_Remove_Matches()
     1000   0.006008556                <SNR>2_AddBufToCurrentTab()

    FUNCTIONS SORTED ON SELF TIME
    count     total (s)      self (s)  function
     1000                 0.112038402  <SNR>2_MRUPop()
     1000   0.029297798   0.025142784  <SNR>7_Highlight_Matching_Pair()
     1000                 0.020331084  <SNR>8_LocalBrowse()
     1000                 0.012291442  <SNR>2_ShouldIgnore()
     1000                 0.011743064  <SNR>2_RemoveBufFromOtherTabs()
     1000   0.028637738   0.010886118  <SNR>2_UpdateTabBufData()
     1500                 0.006926867  <SNR>7_Remove_Matches()
     1000   0.130688003   0.006358159  <SNR>2_MRUPush()
     1000                 0.006008556  <SNR>2_AddBufToCurrentTab()
     1000   0.164370828   0.005045087  <SNR>2_ActivateBuffer()
    ```

  - Using the `mru` branch, this results in:

    ```
    FUNCTIONS SORTED ON TOTAL TIME
    count     total (s)      self (s)  function
     1000   0.081197834   0.008623676  <SNR>2_DoBufEnter()
     1000   0.062542936   0.014577688  <SNR>2_MRUAddBufTab()
     3000   0.035414244   0.024626039  <SNR>2_MRUAdd()
     1000   0.027307881   0.023379796  <SNR>7_Highlight_Matching_Pair()
     1000   0.017889854                <SNR>8_LocalBrowse()
     1000   0.012551004                <SNR>2_ShouldIgnore()
     1000   0.010788205   0.003414017  <SNR>2_MRURemove()
     1000   0.010031222   0.007982058  <SNR>2_MRUEnsureTabId()
     1000   0.007374188                <SNR>2_MRURemoveMustExist()
     1500   0.006580612                <SNR>7_Remove_Matches()
     1000   0.002049164                <SNR>2_GetTabId()

    FUNCTIONS SORTED ON SELF TIME
    count     total (s)      self (s)  function
     3000   0.035414244   0.024626039  <SNR>2_MRUAdd()
     1000   0.027307881   0.023379796  <SNR>7_Highlight_Matching_Pair()
     1000                 0.017889854  <SNR>8_LocalBrowse()
     1000   0.062542936   0.014577688  <SNR>2_MRUAddBufTab()
     1000                 0.012551004  <SNR>2_ShouldIgnore()
     1000   0.081197834   0.008623676  <SNR>2_DoBufEnter()
     1000   0.010031222   0.007982058  <SNR>2_MRUEnsureTabId()
     1000                 0.007374188  <SNR>2_MRURemoveMustExist()
     1500                 0.006580612  <SNR>7_Remove_Matches()
     1000   0.010788205   0.003414017  <SNR>2_MRURemove()
     1000                 0.002049164  <SNR>2_GetTabId()
    ```
