### PR TITLE
Improve terminal buffer display and toggling ability

### DIFF
--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -103,6 +103,7 @@ Commands to use once exploring:
  u             Toggles the showing of "unlisted" buffers.
  V             Open the selected buffer in another window on the left of the current.
  v             Open the selected buffer in another window on the right of the current.
+ X             Toggles the showing of terminal buffers.
 
 Once invoked, Buffer Explorer displays a sorted list (MRU is the default
 sort method) of all the buffers that are currently opened. You are then

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -714,7 +714,7 @@ function! s:MapKeys()
     nnoremap <script> <silent> <nowait> <buffer> u             :call <SID>ToggleShowUnlisted()<CR>
     nnoremap <script> <silent> <nowait> <buffer> v             :call <SID>SelectBuffer("split", "vr")<CR>
     nnoremap <script> <silent> <nowait> <buffer> V             :call <SID>SelectBuffer("split", "vl")<CR>
-    nnoremap <script> <silent> <nowait> <buffer> H             :call <SID>ToggleShowTerminal()<CR>
+    nnoremap <script> <silent> <nowait> <buffer> X             :call <SID>ToggleShowTerminal()<CR>
 
 
     for k in ["G", "n", "N", "L", "M", "H"]
@@ -839,6 +839,7 @@ function! s:CreateHelp()
         call add(header, '" u : toggle showing unlisted buffers')
         call add(header, '" V : open buffer in another window on the left of the current')
         call add(header, '" v : open buffer in another window on the right of the current')
+        call add(header, '" X : toggle showing terminal buffers')
     else
         call add(header, '" Press <F1> for Help')
     endif

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -864,12 +864,78 @@ function! s:CalculateBufferDetails(buf)
     endif
     let buf.isterminal = getbufvar(buf._bufnr, '&buftype') == 'terminal'
     if buf.isterminal
-        let buf.fullname = name
-        let buf.isdir = 0
-    else
-        let buf.fullname = simplify(fnamemodify(name, ':p'))
-        let buf.isdir = getftype(buf.fullname) == "dir"
+        " Neovim uses paths with `term://` prefix, where the provided path
+        " is the current working directory when the terminal was launched, e.g.:
+        " - Unix:
+        "   term://~/tmp/sort//1464953:/bin/bash
+        " - Windows:
+        "   term://C:\apps\nvim-win64\bin//6408:C:\Windows\system32\cmd.exe
+        " Vim uses paths starting with `!`, with no provided path, e.g.:
+        " - Unix:
+        "   !/bin/bash
+        " - Windows:
+        "   !C:\Windows\system32\cmd.exe
+
+        " Use the terminal's current working directory as the `path`.
+        " For `shortname`, use `!PID:shellName`, prefixed with `!` as Vim does,
+        " and without the shell's path for brevity, e.g.:
+        "   `/bin/bash` -> `!bash`
+        "   `1464953:/bin/bash` -> `!1464953:bash`
+        "   `C:\Windows\system32\cmd.exe` -> `!cmd.exe`
+        "   `6408:C:\Windows\system32\cmd.exe` -> `!6408:cmd.exe`
+
+        " Neovim-style name format:
+        "   term://(cwd)//(pid):(shellPath)
+        " e.g.:
+        "   term://~/tmp/sort//1464953:/bin/bash
+        " `cwd` is the directory at terminal launch.
+        let termNameParts = matchlist(name, '\v\c^term://(.*)//(\d+):(.*)$')
+        if len(termNameParts) > 0
+            let [cwd, pidStr, shellPath] = termNameParts[1:3]
+            let pid = str2nr(pidStr)
+            let shellName = fnamemodify(shellPath, ':t')
+        else
+            " Default to Vim's current working directory.
+            let cwd = '.'
+            let shellName = fnamemodify(name, ':t')
+            let pid = -1
+            if exists('*term_getjob') && exists('*job_info')
+                let job = term_getjob(buf._bufnr)
+                if job != v:null
+                    let pid = job_info(job).process
+                endif
+            endif
+        endif
+
+        if pid < 0
+            let shortname = '!' . shellName
+        else
+            let shortname = '!' . pid . ':' . shellName
+            " On some systems having a `/proc` filesystem (e.g., Linux, *BSD,
+            " Solaris), each process has a `cwd` symlink for the current working
+            " directory.  `resolve()` will return the actual current working
+            " directory if possible; otherwise, it will return the symlink path
+            " unchanged.
+            let cwd_symlink = '/proc/' . pid . '/cwd'
+            let resolved_cwd = resolve(cwd_symlink)
+            if resolved_cwd != cwd_symlink
+                let cwd = resolved_cwd
+            endif
+        endif
+
+        let slashed_path = fnamemodify(cwd, ':p')
+        let buf.fullname = slashed_path . shortname
+        let buf.shortname = shortname
+        let homepath = fnamemodify(slashed_path, ':~:h')
+        let buf.path = homepath
+        let buf.homename = fnamemodify(buf.fullname, ':~')
+        let buf.relativepath = fnamemodify(slashed_path, ':~:.:h')
+        let buf.relativename = fnamemodify(buf.fullname, ':~:.')
+        return
     endif
+
+    let buf.fullname = simplify(fnamemodify(name, ':p'))
+    let buf.isdir = getftype(buf.fullname) == "dir"
     if buf.isdir
         " `buf.fullname` ends with a path separator; this will be
         " removed via the first `:h` applied to `buf.fullname` (except


### PR DESCRIPTION
# Overview

- Improve the display of terminal buffers to be a uniform `/current/working/directory/!PID:shellName` on Vim and Neovim.

- Enable the ability to toggle the showing of terminal buffers (via the `X` command).

# Details

## Terminal buffer display format

On Neovim, terminal buffers are named as:

```
term://WorkingDirectoryAtTerminalLaunch//PID:shellPath
```

On Vim, the name contains only a `!` and the shell path:

```
!/path/to/shell
```

In order to sort by `fullpath` in a more useful manner, synthesize a path for terminal buffers based on the shell's current working directory.  Display the shell's name without leading path for brevity.  Terminal buffers are now displayed with this format:

```
/current/working/directory/!PID:shellName
```

At present, the current working directory of the shell can be determined only on Unix-like systems having a `/proc` filesystem.  For other systems, fall back to the directory at terminal launch for Neovim, or else on Vim's current working directory.

It appears to be difficult to determine the current working directory of a program on Windows given the PID, so no attempt is made to determine it for that platform.

## Toggling the showing of terminal buffers

When the feature to toggle showing terminal buffers was introduced, a mapping was added for `H` to perform this toggling in the BufExplorer window; however, the key was inoperable because BufExplorer immediately remapped it (along with some other movement keys).

Because movement keys such as `H` are valuable for navigating the BufExplorer window, the `H` mapping has been changed to use `X` instead, as `X` is normally an editing feature that's not needed in the BufExplorer window.  In addition, this command has been documented.

If a different key (or even no key at all) is preferred for this toggling feature, I'd be happy to adjust the pull request accordingly.
