### PR TITLE
Buffer removal enhancements

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1256,7 +1256,19 @@ function! s:DeleteBuffer(bufNbr, mode)
         else
             execute "silent bdelete" a:bufNbr
         endif
+    catch
+        call s:Error(v:exception)
+    endtry
 
+    if bufexists(a:bufNbr)
+        " Buffer is still present.  We may have failed to wipe it, or it may
+        " have changed attributes (as `:bd` only makes a buffer unlisted).
+        " Regather information on this buffer, update the buffer list, and
+        " redisplay.
+        let info = s:GetBufferInfo(a:bufNbr)
+        let s:raw_buffer_listing[a:bufNbr] = info[a:bufNbr]
+        call s:RedisplayBufferList()
+    else
         " Delete the buffer from the list on screen.
         setlocal modifiable
         normal! "_dd
@@ -1264,9 +1276,7 @@ function! s:DeleteBuffer(bufNbr, mode)
 
         " Delete the buffer from the raw buffer list.
         unlet s:raw_buffer_listing[a:bufNbr]
-    catch
-        call s:Error(v:exception)
-    endtry
+    endif
 endfunction
 
 " Close {{{2

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1150,6 +1150,11 @@ function! s:SelectBuffer(...)
 endfunction
 
 " RemoveBuffer {{{2
+" Valid `mode` values:
+" - "delete"
+" - "force_delete"
+" - "wipe"
+" - "force_wipe"
 function! s:RemoveBuffer(mode)
     " Are we on a line with a file name?
     if line('.') < s:firstBufferLine
@@ -1157,6 +1162,7 @@ function! s:RemoveBuffer(mode)
     endif
 
     let mode = a:mode
+    let forced = mode =~# '^force_'
 
     " These commands are to temporarily suspend the activity of winmanager.
     if exists("b:displayMode") && b:displayMode == "winmanager"
@@ -1165,7 +1171,7 @@ function! s:RemoveBuffer(mode)
 
     let bufNbr = str2nr(getline('.'))
 
-    if getbufvar(bufNbr, '&modified') == 1
+    if !forced && getbufvar(bufNbr, '&modified')
         " Calling confirm() requires Vim built with dialog option.
         if !has("dialog_con") && !has("dialog_gui")
             call s:Error("Sorry, no write since last change for buffer ".bufNbr.", unable to delete")
@@ -1195,6 +1201,11 @@ function! s:RemoveBuffer(mode)
 endfunction
 
 " DeleteBuffer {{{2
+" Valid `mode` values:
+" - "delete"
+" - "force_delete"
+" - "wipe"
+" - "force_wipe"
 function! s:DeleteBuffer(buf, mode)
     " This routine assumes that the buffer to be removed is on the current line.
     try

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -607,7 +607,7 @@ function! BufExplorer()
     " Forget any cached MRU ordering from previous invocations.
     unlet! s:mruOrder
 
-    silent let s:raw_buffer_listing = s:GetBufferInfo(0)
+    let s:raw_buffer_listing = s:GetBufferInfo(0)
 
     call s:MRUGarbageCollectBufs()
     call s:MRUGarbageCollectTabs()
@@ -901,8 +901,9 @@ function! s:GetBufferInfo(bufnr)
     redir => bufoutput
 
     " Show all buffers including the unlisted ones. [!] tells Vim to show the
-    " unlisted ones.
-    buffers!
+    " unlisted ones.  `:silent` allows capturing the output via `:redir`, but
+    " prevents display to the user.
+    silent buffers!
     redir END
 
     if a:bufnr > 0

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1245,6 +1245,11 @@ endfunction
 " - "force_wipe"
 function! s:DeleteBuffer(bufNbr, mode)
     " This routine assumes that the buffer to be removed is on the current line.
+    if a:mode =~# 'delete$' && bufexists(a:bufNbr) && !buflisted(a:bufNbr)
+        call s:Error('Buffer ' . a:bufNbr
+                \ . ' is unlisted; must `wipe` to remove')
+        return
+    endif
     try
         " Wipe/Delete buffer from Vim.
         if a:mode == "wipe"

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1243,18 +1243,18 @@ endfunction
 " - "force_delete"
 " - "wipe"
 " - "force_wipe"
-function! s:DeleteBuffer(buf, mode)
+function! s:DeleteBuffer(bufNbr, mode)
     " This routine assumes that the buffer to be removed is on the current line.
     try
         " Wipe/Delete buffer from Vim.
         if a:mode == "wipe"
-            execute "silent bwipe" a:buf
+            execute "silent bwipe" a:bufNbr
         elseif a:mode == "force_wipe"
-            execute "silent bwipe!" a:buf
+            execute "silent bwipe!" a:bufNbr
         elseif a:mode == "force_delete"
-            execute "silent bdelete!" a:buf
+            execute "silent bdelete!" a:bufNbr
         else
-            execute "silent bdelete" a:buf
+            execute "silent bdelete" a:bufNbr
         endif
 
         " Delete the buffer from the list on screen.
@@ -1263,7 +1263,7 @@ function! s:DeleteBuffer(buf, mode)
         setlocal nomodifiable
 
         " Delete the buffer from the raw buffer list.
-        unlet s:raw_buffer_listing[a:buf]
+        unlet s:raw_buffer_listing[a:bufNbr]
     catch
         call s:Error(v:exception)
     endtry

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -683,6 +683,12 @@ function! s:DisplayBufferList()
     setlocal nomodifiable
 endfunction
 
+" RedisplayBufferList {{{2
+function! s:RedisplayBufferList()
+    call s:RebuildBufferList()
+    call s:UpdateHelpStatus()
+endfunction
+
 " MapKeys {{{2
 function! s:MapKeys()
     if exists("b:displayMode") && b:displayMode == "winmanager"
@@ -1293,22 +1299,19 @@ endfunction
 " ToggleShowTerminal {{{2
 function! s:ToggleShowTerminal()
     let g:bufExplorerShowTerminal = !g:bufExplorerShowTerminal
-    call s:RebuildBufferList()
-    call s:UpdateHelpStatus()
+    call s:RedisplayBufferList()
 endfunction
 
 " ToggleSplitOutPathName {{{2
 function! s:ToggleSplitOutPathName()
     let g:bufExplorerSplitOutPathName = !g:bufExplorerSplitOutPathName
-    call s:RebuildBufferList()
-    call s:UpdateHelpStatus()
+    call s:RedisplayBufferList()
 endfunction
 
 " ToggleShowRelativePath {{{2
 function! s:ToggleShowRelativePath()
     let g:bufExplorerShowRelativePath = !g:bufExplorerShowRelativePath
-    call s:RebuildBufferList()
-    call s:UpdateHelpStatus()
+    call s:RedisplayBufferList()
 endfunction
 
 " ToggleShowTabBuffer {{{2
@@ -1317,22 +1320,19 @@ function! s:ToggleShowTabBuffer()
     " `g:bufExplorerShowTabBuffer`.
     unlet! s:mruOrder
     let g:bufExplorerShowTabBuffer = !g:bufExplorerShowTabBuffer
-    call s:RebuildBufferList()
-    call s:UpdateHelpStatus()
+    call s:RedisplayBufferList()
 endfunction
 
 " ToggleOnlyOneTab {{{2
 function! s:ToggleOnlyOneTab()
     let g:bufExplorerOnlyOneTab = !g:bufExplorerOnlyOneTab
-    call s:RebuildBufferList()
-    call s:UpdateHelpStatus()
+    call s:RedisplayBufferList()
 endfunction
 
 " ToggleShowUnlisted {{{2
 function! s:ToggleShowUnlisted()
     let g:bufExplorerShowUnlisted = !g:bufExplorerShowUnlisted
-    let num_bufs = s:RebuildBufferList()
-    call s:UpdateHelpStatus()
+    call s:RedisplayBufferList()
 endfunction
 
 " ToggleFindActive {{{2

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1163,16 +1163,16 @@ function! s:RemoveBuffer(mode)
         call WinManagerSuspendAUs()
     end
 
-    let _bufNbr = str2nr(getline('.'))
+    let bufNbr = str2nr(getline('.'))
 
-    if getbufvar(_bufNbr, '&modified') == 1
+    if getbufvar(bufNbr, '&modified') == 1
         " Calling confirm() requires Vim built with dialog option.
         if !has("dialog_con") && !has("dialog_gui")
-            call s:Error("Sorry, no write since last change for buffer "._bufNbr.", unable to delete")
+            call s:Error("Sorry, no write since last change for buffer ".bufNbr.", unable to delete")
             return
         endif
 
-        let answer = confirm('No write since last change for buffer '._bufNbr.'. Delete anyway?', "&Yes\n&No", 2)
+        let answer = confirm('No write since last change for buffer '.bufNbr.'. Delete anyway?', "&Yes\n&No", 2)
 
         if a:mode == "delete" && answer == 1
             let mode = "force_delete"
@@ -1185,7 +1185,7 @@ function! s:RemoveBuffer(mode)
     endif
 
     " Okay, everything is good, delete or wipe the buffer.
-    call s:DeleteBuffer(_bufNbr, mode)
+    call s:DeleteBuffer(bufNbr, mode)
 
     " Reactivate winmanager autocommand activity.
     if exists("b:displayMode") && b:displayMode == "winmanager"


### PR DESCRIPTION
# Summary

- Allow deletion/wiping of Neovim terminal buffers (addresses #69).

- Retain buffer until it has been fully wiped.

- Improve error message when deleting an unlisted buffer.

# Details

## Allow deletion/wiping of Neovim terminal buffers

BufExplorer's `d` and `D` commands delete and wipe buffers, respectively, using `:bdelete` and `:bwipe`.  Deleting a buffer makes it unlisted (but still in existence).  Wiping a buffer removes it completely from existence.

For normal buffers, these operations require `!` to force removal when the buffer has been modified.  BufExplorer checks `&modified` to determine when to use `!`.

For terminal buffers, both `:bdelete` and `:bwipe` require `!` to force removal. On Vim, terminal buffers appear to be modified (so `&modified == 1`); however, Neovim terminal buffers have `&modified == 0`, so BufExplorer was not previously asking the user for confirmation nor using `!` during buffer removal, causing removal to fail with errors such as:

```
Vim(bdelete):E89: term://~/testing//816579:/bin/bash will be killed (add ! to override)
```

To allow for Neovim terminal buffer removal, BufExplorer now requires confirmation for terminal buffers using an adjusted prompt for clarity.  For normal buffers, it prompts with:

```
No write since last change for buffer <bufNbr>; Remove anyway?
```

And for terminal buffers, it prompts with:
```
Buffer <bufNbr> is a terminal; Remove anyway?
```

This addresses the majority of issue #69, as it's now possible to remove terminal buffers after confirmation; however, that issue hints at a desire to configure BufExplorer to force-remove buffers unconditionally, which is not (yet) possible.

## Retain buffer until it has been fully wiped

When deleting a buffer with `:bd`, the buffer becomes unlisted.  This means the buffer should remain in the raw buffer list (though with updated attributes), and if unlisted buffers are being displayed, the buffer should stay visible.  It's also possible that wiping a buffer might fail for some reason, in which case the buffer should be retained in the buffer list.

After attempting to remove a buffer (either via `:bd` or `:bw`), if the buffer still exists, regather information on that buffer and update the display accordingly.

## Improve error message when deleting an unlisted buffer

Deleting a listed buffer makes it unlisted.  Deleting an unlisted buffer would do nothing, so `:bd` results in an error message from Vim such as:

```
Vim(bdelete):E516: No buffers were deleted: silent bdelete 1
```

Improve BufExplorer's error message in this case, letting the user know that this is an unlisted buffer that must be wiped to remove it, e.g.:

```
Buffer <bufNbr> is unlisted; must `wipe` to remove
```
