### PR TITLE
Use a separate `syntax/bufexplorer.vim` file for syntax highlighting.

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -670,7 +670,6 @@ function! s:DisplayBufferList()
     setlocal nowrap
     setlocal bufhidden=wipe
 
-    call s:SetupSyntax()
     call s:MapKeys()
 
     " Wipe out any existing lines in case BufExplorer buffer exists and the
@@ -753,51 +752,6 @@ function! s:MapKeys()
     for k in ["G", "n", "N", "L", "M", "H"]
         execute "nnoremap <buffer> <silent>" k ":keepjumps normal!" k."<CR>"
     endfor
-endfunction
-
-" SetupSyntax {{{2
-function! s:SetupSyntax()
-    if has("syntax")
-        syn match bufExplorerHelp     "^\".*" contains=bufExplorerSortBy,bufExplorerMapping,bufExplorerTitle,bufExplorerSortType,bufExplorerToggleSplit,bufExplorerToggleOpen
-        syn match bufExplorerOpenIn   "Open in \w\+ window" contained
-        syn match bufExplorerSplit    "\w\+ split" contained
-        syn match bufExplorerSortBy   "Sorted by .*" contained contains=bufExplorerOpenIn,bufExplorerSplit
-        syn match bufExplorerMapping  "\" \zs.\+\ze :" contained
-        syn match bufExplorerTitle    "Buffer Explorer.*" contained
-        syn match bufExplorerSortType "'\w\{-}'" contained
-        syn match bufExplorerBufNbr   /^\s*\d\+/
-        syn match bufExplorerToggleSplit  "toggle split type" contained
-        syn match bufExplorerToggleOpen   "toggle open mode" contained
-
-        syn match bufExplorerModBuf    /^\s*\d\+.\{4}+.*/
-        syn match bufExplorerLockedBuf /^\s*\d\+.\{3}[\-=].*/
-        syn match bufExplorerHidBuf    /^\s*\d\+.\{2}h.*/
-        syn match bufExplorerActBuf    /^\s*\d\+.\{2}a.*/
-        syn match bufExplorerCurBuf    /^\s*\d\+.%.*/
-        syn match bufExplorerAltBuf    /^\s*\d\+.#.*/
-        syn match bufExplorerUnlBuf    /^\s*\d\+u.*/
-        syn match bufExplorerInactBuf  /^\s*\d\+ \{7}.*/
-
-        hi def link bufExplorerBufNbr Number
-        hi def link bufExplorerMapping NonText
-        hi def link bufExplorerHelp Special
-        hi def link bufExplorerOpenIn Identifier
-        hi def link bufExplorerSortBy String
-        hi def link bufExplorerSplit NonText
-        hi def link bufExplorerTitle NonText
-        hi def link bufExplorerSortType bufExplorerSortBy
-        hi def link bufExplorerToggleSplit bufExplorerSplit
-        hi def link bufExplorerToggleOpen bufExplorerOpenIn
-
-        hi def link bufExplorerActBuf Identifier
-        hi def link bufExplorerAltBuf String
-        hi def link bufExplorerCurBuf Type
-        hi def link bufExplorerHidBuf Constant
-        hi def link bufExplorerLockedBuf Special
-        hi def link bufExplorerModBuf Exception
-        hi def link bufExplorerUnlBuf Comment
-        hi def link bufExplorerInactBuf Comment
-    endif
 endfunction
 
 " ToggleHelp {{{2

--- a/syntax/bufexplorer.vim
+++ b/syntax/bufexplorer.vim
@@ -1,0 +1,54 @@
+" Vim syntax file
+" Language: bufexplorer
+
+if exists("b:current_syntax")
+    finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn match bufExplorerHelp     "^\".*" contains=bufExplorerSortBy,bufExplorerMapping,bufExplorerTitle,bufExplorerSortType,bufExplorerToggleSplit,bufExplorerToggleOpen
+syn match bufExplorerOpenIn   "Open in \w\+ window" contained
+syn match bufExplorerSplit    "\w\+ split" contained
+syn match bufExplorerSortBy   "Sorted by .*" contained contains=bufExplorerOpenIn,bufExplorerSplit
+syn match bufExplorerMapping  "\" \zs.\+\ze :" contained
+syn match bufExplorerTitle    "Buffer Explorer.*" contained
+syn match bufExplorerSortType "'\w\{-}'" contained
+syn match bufExplorerBufNbr   /^\s*\d\+/
+syn match bufExplorerToggleSplit  "toggle split type" contained
+syn match bufExplorerToggleOpen   "toggle open mode" contained
+
+syn match bufExplorerModBuf    /^\s*\d\+.\{4}+.*/
+syn match bufExplorerLockedBuf /^\s*\d\+.\{3}[\-=].*/
+syn match bufExplorerHidBuf    /^\s*\d\+.\{2}h.*/
+syn match bufExplorerActBuf    /^\s*\d\+.\{2}a.*/
+syn match bufExplorerCurBuf    /^\s*\d\+.%.*/
+syn match bufExplorerAltBuf    /^\s*\d\+.#.*/
+syn match bufExplorerUnlBuf    /^\s*\d\+u.*/
+syn match bufExplorerInactBuf  /^\s*\d\+ \{7}.*/
+
+hi def link bufExplorerBufNbr Number
+hi def link bufExplorerMapping NonText
+hi def link bufExplorerHelp Special
+hi def link bufExplorerOpenIn Identifier
+hi def link bufExplorerSortBy String
+hi def link bufExplorerSplit NonText
+hi def link bufExplorerTitle NonText
+hi def link bufExplorerSortType bufExplorerSortBy
+hi def link bufExplorerToggleSplit bufExplorerSplit
+hi def link bufExplorerToggleOpen bufExplorerOpenIn
+
+hi def link bufExplorerActBuf Identifier
+hi def link bufExplorerAltBuf String
+hi def link bufExplorerCurBuf Type
+hi def link bufExplorerHidBuf Constant
+hi def link bufExplorerLockedBuf Special
+hi def link bufExplorerModBuf Exception
+hi def link bufExplorerUnlBuf Comment
+hi def link bufExplorerInactBuf Comment
+
+let b:current_syntax = "bufexplorer"
+
+let &cpo = s:cpo_save
+unlet! s:cpo_save


### PR DESCRIPTION
# Summary

- Instead of setting up syntax highlighting for BufExplorer via a function call, place syntax-related code into `syntax/bufexplorer.vim`.

- This addresses issue #82, wherein BufExplorer syntax highlighting becomes disabled when the `rainbow_csv` plugin executes an "ugly hack" that invokes `:set filetype=bufexplorer`.

# Details

Use Vim's recommended syntax highlighting structure as described in `:help syntax.txt`, where syntax items are defined in the separate file `syntax/bufexplorer.vim`.

With this structure, changes to the buffer's filetype are handled automatically.  This includes redundant changes such as the one done by the `rainbow_csv` plugin's "ugly hacks" commit mentioned in BufExplorer issue #82: https://github.com/mechatroner/rainbow_csv/commit/dbc7be7dd419508c9a5a16d9cac57616135895c8

`rainbow_csv` executes the below command when entering a BufExplorer buffer:

```vim
set filetype=bufexplorer
```

Previously, this had the effect of disabling BufExplorer's syntax highlighting; with the new `syntax/bufexplorer.vim` file in place, syntax highlighting remains active.  This fixes #82.
