### PR TITLE
Add `O` command to open in the original window at BufExplorer launch.

### DIFF
--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -88,6 +88,8 @@ Commands to use once exploring:
  f             Open selected buffer in another window below the current.
  o             Opens the buffer that is under the cursor into the current
                window.
+ O             Opens the buffer that is under the cursor into the window where
+               BufExplorer was originally launched.
  p             Toggles the showing of a split filename/pathname.
  q             Exit/Close bufexplorer.
  r             Reverses the order the buffers are listed in.
@@ -151,6 +153,7 @@ provides.  The mappings are buffer-local to BufExplorer:
   <Plug>(BufExplorer_Close)                    Close BufExplorer window
   <Plug>(BufExplorer_OpenBuffer)               Open buffer
   <Plug>(BufExplorer_OpenBufferAsk)            Prompt for buffer & open
+  <Plug>(BufExplorer_OpenBufferOriginalWindow) Open buffer in original window
   <Plug>(BufExplorer_OpenBufferSplitAbove)     Horizontal split & open above
   <Plug>(BufExplorer_OpenBufferSplitBelow)     Horizontal split & open below
   <Plug>(BufExplorer_OpenBufferSplitLeft)      Vertical split & open left
@@ -183,6 +186,7 @@ BufExplorer's buffer:
   nmap <nowait> <buffer> f        <Plug>(BufExplorer_OpenBufferSplitBelow)
   nmap <nowait> <buffer> F        <Plug>(BufExplorer_OpenBufferSplitAbove)
   nmap <nowait> <buffer> o        <Plug>(BufExplorer_OpenBuffer)
+  nmap <nowait> <buffer> O        <Plug>(BufExplorer_OpenBufferOriginalWindow)
   nmap <nowait> <buffer> p        <Plug>(BufExplorer_ToggleSplitOutPathName)
   nmap <nowait> <buffer> q        <Plug>(BufExplorer_Close)
   nmap <nowait> <buffer> r        <Plug>(BufExplorer_ToggleReverseSort)

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -117,7 +117,6 @@ endfunction
 " Script variables {{{2
 let s:MRU_Exclude_List = ["[BufExplorer]","__MRU_Files__","[Buf\ List]"]
 let s:name = '[BufExplorer]'
-let s:originBuffer = 0
 " Buffer number of the BufExplorer window.
 let s:bufExplorerBuffer = 0
 let s:running = 0
@@ -600,8 +599,6 @@ function! BufExplorer()
         return
     endif
 
-    " Add zero to ensure the variable is treated as a number.
-    let s:originBuffer = bufnr("%") + 0
     let s:tabIdAtLaunch = s:MRUEnsureTabId(tabpagenr())
 
     " Forget any cached MRU ordering from previous invocations.


### PR DESCRIPTION
# Summary

- Add new `O` command to open the buffer under the cursor into the window where BufExplorer was originally launched.

- This addresses issue #55.

# Details

When launching BufExplorer via `:BufExplorer`, the original launch window is reused temporarily for BufExplorer; then, when pressing `<Enter>` to select a buffer, BufExplorer closes and the original launch window is used for the selected buffer.

But when launching BufExplorer via `:BufExplorerHorizontalSplit` or `:BufExplorerVerticalSplit`, a new split is created for BufExplorer.  If `<Enter>` is used to select a buffer, this buffer will be opened in the split created for BufExplorer.

This new `O` command provides a way to first close the split that was created for BufExplorer at launch such that the selected buffer will be opened in the original window.
