### PR TITLE
Fix #131 by handling the case of a completely empty buffer.

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1630,6 +1630,26 @@ function! s:SortListing()
     call s:SortByKeyFunc("<SID>Key_" . g:bufExplorerSortBy)
 endfunction
 
+" BufferNumLines {{{2
+" Return number of lines in the BufExplorer buffer.
+function! s:BufferNumLines()
+    " `line('$')` returns the line number of the last line in a buffer.
+    " Normally, this is the same as the number of lines in the buffer.  When
+    " there are no lines in the buffer, logically `line('$')` should return
+    " zero, but Vim unfortunately returns 1 for this case.  This is because
+    " there must always be a valid line number for the cursor.
+    "
+    " When `line('$') == 1`, we detect an empty buffer by seeing if the first
+    " line itself is empty.  Technically, this cannot distinguish a completely
+    " empty buffer from a one-line buffer with no characters on the first line,
+    " but BufExplorer doesn't create empty lines in the buffer.
+    let numLines = line('$')
+    if numLines == 1 && getline(1) == ''
+        let numLines = 0
+    endif
+    return numLines
+endfunction
+
 " Error {{{2
 " Display a message using ErrorMsg highlight group.
 function! s:Error(msg)

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1206,12 +1206,6 @@ function! s:SelectBuffer(...)
             return
         endif
     else
-        " Are we on a line with a file name?
-        if line('.') < s:firstBufferLine
-            execute "normal! \<CR>"
-            return
-        endif
-
         let _bufNbr = s:GetBufNbrAtCursor()
         if _bufNbr == 0
             return

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1573,7 +1573,7 @@ endfunction
 " SortByKeyFunc {{{2
 function! s:SortByKeyFunc(keyFunc)
     let keyedLines = []
-    for line in getline(s:firstBufferLine, "$")
+    for line in getline(s:firstBufferLine, s:BufferNumLines())
         let key = eval(a:keyFunc . '(line)')
         call add(keyedLines, join(key + [line], "\1"))
     endfor

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1212,7 +1212,10 @@ function! s:SelectBuffer(...)
             return
         endif
 
-        let _bufNbr = str2nr(getline('.'))
+        let _bufNbr = s:GetBufNbrAtCursor()
+        if _bufNbr == 0
+            return
+        endif
 
         " Check and see if we are running BufferExplorer via WinManager.
         if exists("b:displayMode") && b:displayMode == "winmanager"
@@ -1322,7 +1325,10 @@ function! s:RemoveBuffer(mode)
         call WinManagerSuspendAUs()
     end
 
-    let bufNbr = str2nr(getline('.'))
+    let bufNbr = s:GetBufNbrAtCursor()
+    if bufNbr == 0
+        return
+    endif
     let buf = s:raw_buffer_listing[bufNbr]
 
     if !forced && (buf.isterminal || getbufvar(bufNbr, '&modified'))
@@ -1628,6 +1634,22 @@ endfunction
 " SortListing {{{2
 function! s:SortListing()
     call s:SortByKeyFunc("<SID>Key_" . g:bufExplorerSortBy)
+endfunction
+
+" GetBufNbrAtCursor {{{2
+" Return `bufNbr` at cursor; return 0 if no buffer on that line.
+function! s:GetBufNbrAtCursor()
+    return s:GetBufNbrAtLine(line('.'))
+endfunction
+
+" GetBufNbrAtLine {{{2
+" Return `bufNbr` at `lineNbr`; return 0 if no buffer on that line.
+function! s:GetBufNbrAtLine(lineNbr)
+    if a:lineNbr < s:firstBufferLine || a:lineNbr > s:BufferNumLines()
+        return 0
+    endif
+    let lineText = getline(a:lineNbr)
+    return str2nr(lineText)
 endfunction
 
 " BufferNumLines {{{2


### PR DESCRIPTION
When no help text is displayed and there are no buffers to display, the BufExplorer buffer is logically empty; however, Vim does not make it easy to work with completely empty buffers.  For example, `line('$')` returns the last line number in the buffer, which in general is the same as the number of lines in the buffer; but for a completely empty buffer, `line('$')` returns one instead of the expected value of zero.  This is because Vim needs to leave room for the cursor to exist on some line number, even for an empty buffer.  Also, the function `getline(startLineNbr, endLineNbr)` returns a list of the lines in the inclusive range `[startLineNbr, endLineNbr]`, and correctly returns an empty list when `endLineNbr < startLineNbr`; however, the shortcut invocation `getline(startLineNbr, '$')` does not work for a completely empty buffer.  The `'$'` argument is a shortcut for `line('$')`, but since that function cannot return zero, the `getline()` function will not return the desired empty list for a completely empty buffer.

Add a method for accurately counting the number of lines in a buffer and use that to handle the special case of a completely empty buffer.
