### PR TITLE
Allow customization of buffer listing columns

### DIFF
--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -89,10 +89,10 @@ Commands to use once exploring:
                window.
  O             Opens the buffer that is under the cursor into the window where
                BufExplorer was originally launched.
- p             Toggles the showing of a split filename/pathname.
+ p             Toggles splitting a whole path into name and directory.
  q             Exit/Close bufexplorer.
  r             Reverses the order the buffers are listed in.
- R             Toggles relative path/absolute path.
+ R             Toggles showing paths relative to the current working directory.
  s             Cycle thru how the buffers are listed. Either by buffer
                number, file name, file extension, most recently used (MRU), or
                full path.
@@ -186,16 +186,16 @@ WINDOW LAYOUT                                       *bufexplorer-windowlayout*
 
 -------------------------------------------------------------------------------
 " Press <F1> for Help
-" Sorted by mru | Locate buffer | Absolute Split path
+" Sorted by mru | Locate buffer | One tab/buffer | Split path | Show terminal
 "=
   1 %a    bufexplorer.txt      C:\Vim\vimfiles\doc       line 87
   2 #     bufexplorer.vim      c:\Vim\vimfiles\plugin    line 1
 -------------------------------------------------------------------------------
   | |     |                    |                         |
   | |     |                    |                         +-- Current Line #.
-  | |     |                    +-- Relative/Full Path
+  | |     |                    +-- Path (may be Split +/or Relative)
   | |     +-- Buffer Name.
-  | +-- Buffer Attributes. See |:buffers| for more information.
+  | +-- Buffer Indicators. See |:buffers| for more information.
   +-- Buffer Number. See |:buffers| for more information.
 
 ===============================================================================
@@ -267,6 +267,7 @@ BufExplorer's buffer:
   nmap <nowait> <buffer> V        <Plug>(BufExplorer_OpenBufferSplitLeft)
   nmap <nowait> <buffer> X        <Plug>(BufExplorer_ToggleShowTerminal)
 
+                                                          *BufExplorer_Started*
 These buffer-local mappings may be adjusted as desired after BufExplorer has
 been launched, typically by use of an autocommand.  At BufExplorer startup, a
 |User| autocommand will be sent with an autocommand pattern of
@@ -307,6 +308,238 @@ be called to adjust BufExplorer's mappings: >
 
       " Example: Map the `t` key to `<Nop>` to prevent opening in a tab.
       nmap <nowait> <buffer> t <Nop>
+  endfunction
+<
+                                                         *g:bufExplorerColumns*
+The columns displayed in the buffer list are configurable via the variable
+`g:bufExplorerColumns`.  This is a list of strings, where each string dictates
+the contents of a column in the buffer list.  Most strings relate to properties
+of the buffer being displayed, and most properties are taken from the output of
+`:buffers`; see Vim's help for |:buffers| for details on the interpretation of
+these properties.
+
+For a file:
+- A "path" is the location of the file.
+- A "dir" is the directory portion of a path.
+- A "name" is a path with the directory portion removed.
+
+Paths of files and directories may be modified via a prefix:
+- `full` - the full location starting from the root directory.
+- `homerel` - `full` but with any home directory prefix replaced with `~/`.
+- `relative` - `homerel` but shortened relative to current directory.
+
+BufExplorer defines the following column strings:
+
+Column String               Meaning
+------------------------    ------------------------------------------------
+`number`                      buffer number from `:buffers`
+`indicators`                  indicators from `:buffers`
+`numberindicators`            number and indicators in the same column
+`line`                        line number from `:buffers`
+`rawpath`                     raw path as returned by `:buffers`
+`name`                        path with directory portion removed
+`fullpath`                    file location starting from root directory
+`fulldir`                     directory location starting from root directory
+`homerelpath`                 `fullpath` with homerel shortening
+`homereldir`                  `fulldir` with homerel shortening
+`relativepath`                `homerelpath` with relative shortening
+`relativedir`                 `homereldir` with relative shortening
+`path`                        `relativedir` or `homereldir;` see below
+`dir`                         `relativedir` or `homereldir;` see below
+`splittablepath`              `[path]` or `[name, dir]`; see below
+`icon`                        icon from VimDevIcons
+
+In the examples that follow the user `vimmer` has home directory `/home/vimmer`
+with the following contents: >
+
+  /home/
+    vimmer/                 <- Home directory
+      notes/                <- Current working directory
+        todo.txt
+        shopping/
+          laptop.txt
+<
+The current working directory is `/home/vimmer/notes`.
+
+The files are open in Vim; the output of `:buffers` is: >
+
+    4 %a   "todo.txt"                     line 23
+    6 #h   "shopping/laptop.txt"          line 18
+<
+For buffer 4 (`todo.txt`): >
+
+  rawpath           ->  todo.txt
+  name              ->  todo.txt
+  fullpath          ->  /home/vimmer/notes/todo.txt
+  fulldir           ->  /home/vimmer/notes
+  homerelpath       ->  ~/notes/todo.txt
+  homereldir        ->  ~/notes
+  relativepath      ->  todo.txt
+  relativedir       ->  .
+  number            ->  4
+  indicators        ->  %a
+  numberindicators  ->  4 %a
+  line              ->  line 23
+<
+For buffer 6 (`shopping/laptop.txt`): >
+
+  rawpath           ->  shopping/laptop.txt
+  name              ->  laptop.txt
+  fullpath          ->  /home/vimmer/notes/shopping/laptop.txt
+  fulldir           ->  /home/vimmer/notes/shopping
+  homerelpath       ->  ~/notes/shopping/laptop.txt
+  homereldir        ->  ~/notes/shopping
+  relativepath      ->  laptop.txt
+  relativedir       ->  shopping
+  number            ->  6
+  indicators        ->  #h
+  numberindicators  ->  6 #h
+  line              ->  line 18
+<
+Certain column strings are dynamically calculated based on current BufExplorer
+display mode: >
+
+  if g:bufExplorerSplitOutPathName:
+      [splittablepath] => [name, dir]
+  else:
+      [splittablepath] => [path]
+
+  if g:bufExplorerShowRelativePath:
+      [dir]  -> [relativedir]
+      [path] -> [relativepath]
+  else:
+      [dir]  -> [homereldir]
+      [path] -> [homerelpath]
+<
+Thus, `splittablepath` will be split into two columns (`name` and `dir`) when
+`g:bufExplorerSplitOutPathName=1`, and kept as `path` in a single column
+otherwise.
+
+`dir` and `path` will have a `relative` prefix when
+`g:bufExplorerShowRelativePath=1` and a `homerel` prefix otherwise.
+
+If the VimDevIcons plugin (https://github.com/ryanoasis/vim-devicons) is
+installed, then the `icon` column string creates a column with the appropriate
+icon; otherwise, no icon column will be created.  See the VimDevIcons plugin
+documentation for more details.
+
+For example, to show only the buffer's number and path, add the below to your
+vimrc: >
+
+  let g:bufExplorerColumns = ['number', 'splittablepath']
+<
+To show only the buffer's path, add the below to your vimrc: >
+
+  let g:bufExplorerColumns = ['splittablepath']
+<
+In addition to the above column strings, any string starting with `=` will be
+inserted into the column literally.  So, for example, the string `=|` results in
+a column of vertical bars: >
+
+  let g:bufExplorerColumns = ['number', '=|', 'splittablepath']
+
+And the string `=    `  (`=` plus four spaces) adds a column of extra spaces: >
+
+  let g:bufExplorerColumns = ['number', '=    ', 'splittablepath']
+<
+                                                 *BufExplorer_defaultColumns()*
+The default list of columns is given by `BufExplorer_defaultColumns()`.  At
+BufExplorer startup, `g:bufExplorerColumns` will be set to this default if that
+variable is undefined.  The default list is: >
+
+  ['numberindicators', 'icon', 'splittablepath', 'line']
+<
+                                                      *BufExplorer_redisplay()*
+It's useful to request a re-display of the buffer list if the columns are being
+changed dynamically.  `BufExplorer_redisplay()` causes BufExplorer to redisplay
+the buffer list according to the columns defined by `g:bufExplorerColumns`.
+The example below uses the key `q` to toggle between the default view and the
+"quiet" view above that shows only the buffer's path: >
+
+  " `UserPrefix_` is an arbitrary prefix to avoid name collisions.
+  augroup UserPrefix_BufExplorerGroup
+      autocmd!
+      autocmd User BufExplorer_Started call <SID>BufExplorer_Started()
+  augroup END
+
+  function! s:BufExplorer_Started()
+      nmap <nowait> <buffer> <silent> q :call <SID>toggleQuiet()<CR>
+  endfunction
+
+  let s:quiet = 0
+
+  function! s:toggleQuiet()
+      let s:quiet = !s:quiet
+      if s:quiet
+          let g:bufExplorerColumns = ['splittablepath']
+      else
+          let g:bufExplorerColumns = BufExplorer_defaultColumns()
+      endif
+      call BufExplorer_redisplay()
+  endfunction
+<
+The following example uses `=` to reset some BufExplorer settings to some
+preferred set and then redisplay: >
+
+  augroup UserPrefix_BufExplorerGroup
+      autocmd!
+      autocmd User BufExplorer_Started call UserPrefix_setupBufExplorer()
+  augroup END
+
+  function! UserPrefix_setupBufExplorer()
+      " Example: Make `=` reset to preferred settings and redisplay.
+      nmap <nowait> <buffer> <silent> = :call <SID>reset()<CR>
+  endfunction
+
+  function! s:reset()
+      let g:bufExplorerSortBy = 'fullpath'
+      let g:bufExplorerSplitOutPathName = 1
+      let g:bufExplorerShowRelativePath = 1
+      call BufExplorer_redisplay()
+  endfunction
+<
+                                                       *BufExplorer_PreDisplay*
+Before displaying (or redisplaying) a buffer list, BufExplorer will send a
+|User| autocommand with an autocommand pattern of `BufExplorer_PreDisplay`.
+This event may be caught via an |:autocmd|, allowing for last-minute adjustments
+to the buffer list columns.  For example, consider customizing BufExplorer's `R`
+command to cycle among `homerel`, `relative`, and `full` prefixes instead of
+just toggling between `homerel` and `relative`.  Note that the `p` command
+influences the choice of columns, so the calculation must be done during the
+`BufExplorer_PreDisplay` event: >
+
+  " `UserPrefix_` is an arbitrary prefix to avoid name collisions.
+  augroup UserPrefix_BufExplorerGroup
+      autocmd!
+      autocmd User BufExplorer_Started call <SID>BufExplorer_Started()
+      autocmd User BufExplorer_PreDisplay call <SID>BufExplorer_PreDisplay()
+  augroup END
+
+  function! s:BufExplorer_Started()
+      nmap <nowait> <buffer> <silent> R :call <SID>cycleRelative()<CR>
+  endfunction
+
+  let s:relTypeIndex = 0
+  let s:relTypes = ['homerel', 'relative', 'full']
+
+  function! s:BufExplorer_PreDisplay()
+      let g:bufExplorerColumns = BufExplorer_defaultColumns()
+      let pathIndex = index(g:bufExplorerColumns, 'splittablepath')
+      call remove(g:bufExplorerColumns, pathIndex)
+      let prefix = s:relTypes[s:relTypeIndex]
+      if g:bufExplorerSplitOutPathName
+          call insert(g:bufExplorerColumns, 'name', pathIndex)
+          let pathIndex += 1
+          let suffix = 'dir'
+      else
+          let suffix = 'path'
+      endif
+      call insert(g:bufExplorerColumns, prefix . suffix, pathIndex)
+  endfunction
+
+  function! s:cycleRelative()
+      let s:relTypeIndex = (s:relTypeIndex  + 1 ) % len(s:relTypes)
+      call BufExplorer_redisplay()
   endfunction
 <
                                                           *g:bufExplorerChgWin*
@@ -386,11 +619,10 @@ To control whether to show "No Name" buffers or not, use: >
 The default is to NOT show "No Name buffers.
 
                                                 *g:bufExplorerShowRelativePath*
-To control whether to show absolute paths or relative to the current
-directory, use: >
-  let g:bufExplorerShowRelativePath=0  " Show absolute paths.
+To control whether to show paths relative to the current directory, use: >
+  let g:bufExplorerShowRelativePath=0  " Do not show relative paths.
   let g:bufExplorerShowRelativePath=1  " Show relative paths.
-The default is to show absolute paths.
+The default is to NOT show relative paths.
 
                                                    *g:bufExplorerShowTabBuffer*
 To control whether or not to show buffers on for the specific tab or not, use: >
@@ -428,11 +660,10 @@ To control the size of the new horizontal split window. use: >
 The default is 0, so that the size is set by Vim.
 
                                                 *g:bufExplorerSplitOutPathName*
-To control whether to split out the path and file name or not, use: >
-  let g:bufExplorerSplitOutPathName=1  " Split the path and file name.
-  let g:bufExplorerSplitOutPathName=0  " Don't split the path and file
-                                       " name.
-The default is to split the path and file name.
+To control whether to split the path into name + directory columns, use: >
+  let g:bufExplorerSplitOutPathName=1  " Split the path into name + directory.
+  let g:bufExplorerSplitOutPathName=0  " Don't split the path.
+The default is to split path into name + directory columns.
 
                                                       *g:bufExplorerSplitRight*
 To control where the new vsplit window will be placed to the left or right of

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1592,50 +1592,43 @@ function! s:UpdateHelpStatus()
 endfunction
 
 " Key_number {{{2
-function! s:Key_number(line)
-    let bufNbr = str2nr(a:line)
-    let key = [printf('%9d', bufNbr)]
+function! s:Key_number(buf)
+    let key = [printf('%9d', a:buf.bufNbr)]
     return key
 endfunction
 
 " Key_name {{{2
-function! s:Key_name(line)
-    let bufNbr = str2nr(a:line)
-    let buf = s:raw_buffer_listing[bufNbr]
-    let key = [buf.name, buf.fullpath]
+function! s:Key_name(buf)
+    let key = [a:buf.name, a:buf.fullpath]
     return key
 endfunction
 
 " Key_fullpath {{{2
-function! s:Key_fullpath(line)
-    let bufNbr = str2nr(a:line)
-    let buf = s:raw_buffer_listing[bufNbr]
-    let key = [buf.fullpath]
+function! s:Key_fullpath(buf)
+    let key = [a:buf.fullpath]
     return key
 endfunction
 
 " Key_extension {{{2
-function! s:Key_extension(line)
-    let bufNbr = str2nr(a:line)
-    let buf = s:raw_buffer_listing[bufNbr]
-    let extension = fnamemodify(buf.name, ':e')
-    let key = [extension, buf.name, buf.fullpath]
+function! s:Key_extension(buf)
+    let extension = fnamemodify(a:buf.name, ':e')
+    let key = [extension, a:buf.name, a:buf.fullpath]
     return key
 endfunction
 
 " Key_mru {{{2
-function! s:Key_mru(line)
-    let bufNbr = str2nr(a:line)
-    let buf = s:raw_buffer_listing[bufNbr]
-    let pos = s:MRUOrderForBuf(bufNbr)
-    return [printf('%9d', pos), buf.fullpath]
+function! s:Key_mru(buf)
+    let pos = s:MRUOrderForBuf(a:buf.bufNbr)
+    return [printf('%9d', pos), a:buf.fullpath]
 endfunction
 
 " SortByKeyFunc {{{2
 function! s:SortByKeyFunc(keyFunc)
     let keyedLines = []
     for line in getline(s:firstBufferLine, s:BufferNumLines())
-        let key = eval(a:keyFunc . '(line)')
+        let bufNbr = str2nr(line)
+        let buf = s:raw_buffer_listing[bufNbr]
+        let key = eval(a:keyFunc . '(buf)')
         call add(keyedLines, join(key + [line], "\1"))
     endfor
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -950,7 +950,7 @@ endfunction
 " Calculate `buf`-related details.
 " Only these fields of `buf` must be defined on entry:
 " - `.bufNbr`
-" - `.attributes`
+" - `.numberindicators`
 " - `.line`
 function! s:CalculateBufferDetails(buf)
     let buf = a:buf
@@ -1065,7 +1065,7 @@ endfunction
 " - If `onlyBufNbr > 0`, dictionary will contain at most that buffer.
 " On return, only these fields are set for each `buf`:
 " - `.bufNbr`
-" - `.attributes`
+" - `.numberindicators`
 " - `.line`
 " Other fields will be populated by `s:CalculateBufferDetails()`.
 function! s:GetBufferInfo(onlyBufNbr)
@@ -1091,7 +1091,7 @@ function! s:GetBufferInfo(onlyBufNbr)
         " more spaces/tabs:
         let onlyLinePattern = '\v\n\s*'
         " Continue with the buffer number followed by a non-digit character
-        " (which will be a buffer attribute character such as `u` or ` `).
+        " (which will be a buffer indicator character such as `u` or ` `).
         let onlyLinePattern .= a:onlyBufNbr . '\D'
         " Finish with a run of zero or more non-newline characters plus newline:
         let onlyLinePattern .= '[^\n]*\n'
@@ -1106,8 +1106,12 @@ function! s:GetBufferInfo(onlyBufNbr)
 
         " Use first and last components after the split on '"', in case a
         " filename with an embedded '"' is present.
-        let buf = {"attributes": bits[0], "line": substitute(bits[-1], '\s*', '', '')}
-        let buf.bufNbr = str2nr(buf.attributes)
+        let buf = {
+                \ "numberindicators": bits[0],
+                \ "line": substitute(bits[-1],
+                \ '\s*', '', '')
+                \}
+        let buf.bufNbr = str2nr(buf.numberindicators)
         let all[buf.bufNbr] = buf
     endfor
 
@@ -1120,7 +1124,7 @@ function! s:BuildBufferList()
 
     " Loop through every buffer.
     for buf in values(s:raw_buffer_listing)
-        " `buf.attributes` must exist, but we defer the expensive work of
+        " `buf.numberindicators` must exist, but we defer the expensive work of
         " calculating other buffer details (e.g., `buf.fullpath`) until we know
         " the user wants to view this buffer.
 
@@ -1130,7 +1134,7 @@ function! s:BuildBufferList()
         endif
 
         " Skip unlisted buffers if we are not to show them.
-        if !g:bufExplorerShowUnlisted && buf.attributes =~ "u"
+        if !g:bufExplorerShowUnlisted && buf.numberindicators =~ "u"
             " Skip unlisted buffers if we are not to show them.
             continue
         endif
@@ -1160,7 +1164,7 @@ function! s:BuildBufferList()
             continue
         endif
 
-        let row = [buf.attributes]
+        let row = [buf.numberindicators]
 
         if exists("g:loaded_webdevicons")
             let row += [WebDevIconsGetFileTypeSymbol(buf.fullpath, buf.isdir)]
@@ -1435,7 +1439,7 @@ function! s:DeleteBuffer(bufNbr, mode)
 
     if bufexists(a:bufNbr)
         " Buffer is still present.  We may have failed to wipe it, or it may
-        " have changed attributes (as `:bd` only makes a buffer unlisted).
+        " have changed indicators (as `:bd` only makes a buffer unlisted).
         " Regather information on this buffer, update the buffer list, and
         " redisplay.
         let info = s:GetBufferInfo(a:bufNbr)

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1024,13 +1024,13 @@ function! s:CalculateBufferDetails(buf)
             endif
         endif
 
-        let slashed_path = fnamemodify(cwd, ':p')
-        let buf.fullpath = slashed_path . name
-        let buf.fulldir = fnamemodify(slashed_path, ':h')
+        let slashed_cwd = fnamemodify(cwd, ':p')
+        let buf.fullpath = slashed_cwd . name
+        let buf.fulldir = fnamemodify(slashed_cwd, ':h')
         let buf.name = name
-        let buf.homereldir = fnamemodify(slashed_path, ':~:h')
+        let buf.homereldir = fnamemodify(slashed_cwd, ':~:h')
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
-        let buf.relativedir = fnamemodify(slashed_path, ':~:.:h')
+        let buf.relativedir = fnamemodify(slashed_cwd, ':~:.:h')
         let buf.relativepath = fnamemodify(buf.fullpath, ':~:.')
         return
     endif

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1467,6 +1467,8 @@ function! s:DeleteBuffer(bufNbr, mode)
 
         " Delete the buffer from the raw buffer list.
         unlet s:raw_buffer_listing[a:bufNbr]
+        " Remove buffer number from list of displayed buffer numbers.
+        call remove(s:displayedBufNbrs, index(s:displayedBufNbrs, a:bufNbr))
     endif
 endfunction
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1044,8 +1044,10 @@ function! s:CalculateBufferDetails(buf)
         " Must perform shortening (`:~`, `:.`) before `:h`.
         let buf.homerelpath = fnamemodify(fullpath, ':~:h')
         let buf.relativepath = fnamemodify(fullpath, ':~:.:h')
-        let parent = fnamemodify(fullpath, ':h:h')
-        let buf.name = fnamemodify(fullpath, ':h:t')
+        " Remove trailing slash.
+        let fullpath = fnamemodify(fullpath, ':h')
+        let parent = fnamemodify(fullpath, ':h')
+        let buf.name = fnamemodify(fullpath, ':t')
         " Special case for root directory: fnamemodify('/', ':h:t') == ''
         if buf.name == ''
             let buf.name = '.'

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1040,15 +1040,16 @@ function! s:CalculateBufferDetails(buf)
         " `fullpath` ends with a path separator; this will be
         " removed via the first `:h` applied to `fullpath` (except
         " for the root directory, where the path separator will remain).
+
+        " Must perform shortening (`:~`, `:.`) before `:h`.
+        let buf.homerelpath = fnamemodify(fullpath, ':~:h')
+        let buf.relativepath = fnamemodify(fullpath, ':~:.:h')
         let parent = fnamemodify(fullpath, ':h:h')
         let buf.name = fnamemodify(fullpath, ':h:t')
         " Special case for root directory: fnamemodify('/', ':h:t') == ''
         if buf.name == ''
             let buf.name = '.'
         endif
-        " Must perform shortening (`:~`, `:.`) before `:h`.
-        let buf.homerelpath = fnamemodify(fullpath, ':~:h')
-        let buf.relativepath = fnamemodify(fullpath, ':~:.:h')
     else
         let parent = fnamemodify(fullpath, ':h')
         let buf.name = fnamemodify(fullpath, ':t')

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -901,17 +901,17 @@ endfunction
 " CalculateBufferDetails {{{2
 " Calculate `buf`-related details.
 " Only these fields of `buf` must be defined on entry:
-" - `._bufnr`
+" - `.bufNbr`
 " - `.attributes`
 " - `.line`
 function! s:CalculateBufferDetails(buf)
     let buf = a:buf
-    let name = bufname(buf._bufnr)
+    let name = bufname(buf.bufNbr)
     let buf["hasNoName"] = empty(name)
     if buf.hasNoName
         let name = "[No Name]"
     endif
-    let buf.isterminal = getbufvar(buf._bufnr, '&buftype') == 'terminal'
+    let buf.isterminal = getbufvar(buf.bufNbr, '&buftype') == 'terminal'
     if buf.isterminal
         " Neovim uses paths with `term://` prefix, where the provided path
         " is the current working directory when the terminal was launched, e.g.:
@@ -949,7 +949,7 @@ function! s:CalculateBufferDetails(buf)
             let shellName = fnamemodify(name, ':t')
             let pid = -1
             if exists('*term_getjob') && exists('*job_info')
-                let job = term_getjob(buf._bufnr)
+                let job = term_getjob(buf.bufNbr)
                 if job != v:null
                     let pid = job_info(job).process
                 endif
@@ -1015,7 +1015,7 @@ endfunction
 " Return dictionary `{ bufNbr : buf }`.
 " - If `onlyBufNbr > 0`, dictionary will contain at most that buffer.
 " On return, only these fields are set for each `buf`:
-" - `._bufnr`
+" - `.bufNbr`
 " - `.attributes`
 " - `.line`
 " Other fields will be populated by `s:CalculateBufferDetails()`.
@@ -1058,8 +1058,8 @@ function! s:GetBufferInfo(onlyBufNbr)
         " Use first and last components after the split on '"', in case a
         " filename with an embedded '"' is present.
         let buf = {"attributes": bits[0], "line": substitute(bits[-1], '\s*', '', '')}
-        let buf._bufnr = str2nr(buf.attributes)
-        let all[buf._bufnr] = buf
+        let buf.bufNbr = str2nr(buf.attributes)
+        let all[buf.bufNbr] = buf
     endfor
 
     return all
@@ -1076,7 +1076,7 @@ function! s:BuildBufferList()
         " the user wants to view this buffer.
 
         " Skip BufExplorer's buffer.
-        if buf._bufnr == s:bufExplorerBuffer
+        if buf.bufNbr == s:bufExplorerBuffer
             continue
         endif
 
@@ -1097,7 +1097,7 @@ function! s:BuildBufferList()
         endif
 
         " Should we show this buffer in this tab?
-        if !s:MRUTabShouldShowBuf(s:tabIdAtLaunch, buf._bufnr)
+        if !s:MRUTabShouldShowBuf(s:tabIdAtLaunch, buf.bufNbr)
             continue
         endif
 
@@ -1531,31 +1531,31 @@ endfunction
 
 " Key_number {{{2
 function! s:Key_number(line)
-    let _bufnr = str2nr(a:line)
-    let key = [printf('%9d', _bufnr)]
+    let bufNbr = str2nr(a:line)
+    let key = [printf('%9d', bufNbr)]
     return key
 endfunction
 
 " Key_name {{{2
 function! s:Key_name(line)
-    let _bufnr = str2nr(a:line)
-    let buf = s:raw_buffer_listing[_bufnr]
+    let bufNbr = str2nr(a:line)
+    let buf = s:raw_buffer_listing[bufNbr]
     let key = [buf.shortname, buf.fullname]
     return key
 endfunction
 
 " Key_fullpath {{{2
 function! s:Key_fullpath(line)
-    let _bufnr = str2nr(a:line)
-    let buf = s:raw_buffer_listing[_bufnr]
+    let bufNbr = str2nr(a:line)
+    let buf = s:raw_buffer_listing[bufNbr]
     let key = [buf.fullname]
     return key
 endfunction
 
 " Key_extension {{{2
 function! s:Key_extension(line)
-    let _bufnr = str2nr(a:line)
-    let buf = s:raw_buffer_listing[_bufnr]
+    let bufNbr = str2nr(a:line)
+    let buf = s:raw_buffer_listing[bufNbr]
     let extension = fnamemodify(buf.shortname, ':e')
     let key = [extension, buf.shortname, buf.fullname]
     return key
@@ -1563,9 +1563,9 @@ endfunction
 
 " Key_mru {{{2
 function! s:Key_mru(line)
-    let _bufnr = str2nr(a:line)
-    let buf = s:raw_buffer_listing[_bufnr]
-    let pos = s:MRUOrderForBuf(_bufnr)
+    let bufNbr = str2nr(a:line)
+    let buf = s:raw_buffer_listing[bufNbr]
+    let pos = s:MRUOrderForBuf(bufNbr)
     return [printf('%9d', pos), buf.fullname]
 endfunction
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -954,10 +954,10 @@ endfunction
 " - `.line`
 function! s:CalculateBufferDetails(buf)
     let buf = a:buf
-    let name = bufname(buf.bufNbr)
-    let buf["hasNoName"] = empty(name)
+    let rawpath = bufname(buf.bufNbr)
+    let buf["hasNoName"] = empty(rawpath)
     if buf.hasNoName
-        let name = "[No Name]"
+        let rawpath = "[No Name]"
     endif
     let buf.isterminal = getbufvar(buf.bufNbr, '&buftype') == 'terminal'
     if buf.isterminal
@@ -986,7 +986,7 @@ function! s:CalculateBufferDetails(buf)
         " e.g.:
         "   term://~/tmp/sort//1464953:/bin/bash
         " `cwd` is the directory at terminal launch.
-        let termNameParts = matchlist(name, '\v\c^term://(.*)//(\d+):(.*)$')
+        let termNameParts = matchlist(rawpath, '\v\c^term://(.*)//(\d+):(.*)$')
         if len(termNameParts) > 0
             let [cwd, pidStr, shellPath] = termNameParts[1:3]
             let pid = str2nr(pidStr)
@@ -994,7 +994,7 @@ function! s:CalculateBufferDetails(buf)
         else
             " Default to Vim's current working directory.
             let cwd = '.'
-            let shellName = fnamemodify(name, ':t')
+            let shellName = fnamemodify(rawpath, ':t')
             let pid = -1
             if exists('*term_getjob') && exists('*job_info')
                 let job = term_getjob(buf.bufNbr)
@@ -1031,7 +1031,7 @@ function! s:CalculateBufferDetails(buf)
         return
     endif
 
-    let buf.fullname = simplify(fnamemodify(name, ':p'))
+    let buf.fullname = simplify(fnamemodify(rawpath, ':p'))
     let buf.isdir = getftype(buf.fullname) == "dir"
     if buf.isdir
         " `buf.fullname` ends with a path separator; this will be

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1187,7 +1187,7 @@ function! s:SelectBuffer(...)
     " error has occurred when it really has not.
     "echo ""
 
-    let _bufNbr = -1
+    let bufNbr = -1
 
     if (a:0 == 1) && (a:1 == "ask")
         " Ask the user for input.
@@ -1199,20 +1199,20 @@ function! s:SelectBuffer(...)
         redraw | echo
 
         if strlen(cmd) > 0
-            let _bufNbr = str2nr(cmd)
+            let bufNbr = str2nr(cmd)
         else
             call s:Error("Invalid buffer number, try again.")
             return
         endif
     else
-        let _bufNbr = s:GetBufNbrAtCursor()
-        if _bufNbr == 0
+        let bufNbr = s:GetBufNbrAtCursor()
+        if bufNbr == 0
             return
         endif
 
         " Check and see if we are running BufferExplorer via WinManager.
         if exists("b:displayMode") && b:displayMode == "winmanager"
-            let _bufName = expand("#"._bufNbr.":p")
+            let _bufName = expand("#".bufNbr.":p")
 
             if (a:0 == 1) && (a:1 == "tab")
                 call WinManagerFileEdit(_bufName, 1)
@@ -1224,12 +1224,12 @@ function! s:SelectBuffer(...)
         endif
     endif
 
-    if bufexists(_bufNbr)
+    if bufexists(bufNbr)
         " Get the tab number where this buffer is located in.
-        let tabNbr = s:GetTabNbr(_bufNbr)
+        let tabNbr = s:GetTabNbr(bufNbr)
         if exists("g:bufExplorerChgWin") && g:bufExplorerChgWin <=winnr("$")
             execute g:bufExplorerChgWin."wincmd w"
-            execute "keepjumps keepalt silent b!" _bufNbr
+            execute "keepjumps keepalt silent b!" bufNbr
 
         " Are we supposed to open the selected buffer in a tab?
         elseif (a:0 == 1) && (a:1 == "tab")
@@ -1238,42 +1238,42 @@ function! s:SelectBuffer(...)
             " Open a new tab with the selected buffer in it.
             if v:version > 704 || ( v:version == 704 && has('patch2237') )
                 " new syntax for last tab as of 7.4.2237
-                execute "$tab split +buffer" . _bufNbr
+                execute "$tab split +buffer" . bufNbr
             else
-                execute "999tab split +buffer" . _bufNbr
+                execute "999tab split +buffer" . bufNbr
             endif
         " Are we supposed to open the selected buffer in a split?
         elseif (a:0 == 2) && (a:1 == "split")
             call s:Close()
             if (a:2 == "vl")
-                execute "vert topleft sb "._bufNbr
+                execute "vert topleft sb ".bufNbr
             elseif (a:2 == "vr")
-                execute "vert belowright sb "._bufNbr
+                execute "vert belowright sb ".bufNbr
             elseif (a:2 == "st")
-                execute "topleft sb "._bufNbr
+                execute "topleft sb ".bufNbr
             else " = sb
-                execute "belowright sb "._bufNbr
+                execute "belowright sb ".bufNbr
             endif
         " Are we supposed to open the selected buffer in the original window?
         elseif (a:0 == 1) && (a:1 == "original_window")
             call s:Close()
             execute s:windowAtLaunch . "wincmd w"
-            execute "keepjumps keepalt silent b!" _bufNbr
+            execute "keepjumps keepalt silent b!" bufNbr
         else
             " Request to open in current (BufExplorer) window.
             if g:bufExplorerFindActive && tabNbr > 0
                 " Close BufExplorer window and switch to existing tab/window.
                 call s:Close()
                 execute tabNbr . "tabnext"
-                execute bufwinnr(_bufNbr) . "wincmd w"
+                execute bufwinnr(bufNbr) . "wincmd w"
             else
                 " Use BufExplorer window for the buffer.
-                execute "keepjumps keepalt silent b!" _bufNbr
+                execute "keepjumps keepalt silent b!" bufNbr
             endif
         endif
 
         " Make the buffer 'listed' again.
-        call setbufvar(_bufNbr, "&buflisted", "1")
+        call setbufvar(bufNbr, "&buflisted", "1")
 
         " Call any associated function references. g:bufExplorerFuncRef may be
         " an individual function reference or it may be a list containing
@@ -1294,7 +1294,7 @@ function! s:SelectBuffer(...)
         endif
     else
         call s:Error("Sorry, that buffer no longer exists, please select another")
-        call s:DeleteBuffer(_bufNbr, "wipe")
+        call s:DeleteBuffer(bufNbr, "wipe")
     endif
 endfunction
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -962,6 +962,7 @@ function! s:CalculateBufferDetails(buf)
     else
         let buf.isdir = getftype(rawpath) == 'dir'
     endif
+    let buf.rawpath = rawpath
     let buf.isterminal = getbufvar(buf.bufNbr, '&buftype') == 'terminal'
     if buf.isterminal
         " Neovim uses paths with `term://` prefix, where the provided dir path

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -958,6 +958,9 @@ function! s:CalculateBufferDetails(buf)
     let buf["hasNoName"] = empty(rawpath)
     if buf.hasNoName
         let rawpath = "[No Name]"
+        let buf.isdir = 0
+    else
+        let buf.isdir = getftype(rawpath) == 'dir'
     endif
     let buf.isterminal = getbufvar(buf.bufNbr, '&buftype') == 'terminal'
     if buf.isterminal
@@ -1032,7 +1035,6 @@ function! s:CalculateBufferDetails(buf)
     endif
 
     let buf.fullname = simplify(fnamemodify(rawpath, ':p'))
-    let buf.isdir = getftype(buf.fullname) == "dir"
     if buf.isdir
         " `buf.fullname` ends with a path separator; this will be
         " removed via the first `:h` applied to `buf.fullname` (except

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1028,7 +1028,7 @@ function! s:CalculateBufferDetails(buf)
         let buf.shortname = shortname
         let buf.homereldir = fnamemodify(slashed_path, ':~:h')
         let buf.homename = fnamemodify(buf.fullname, ':~')
-        let buf.relativepath = fnamemodify(slashed_path, ':~:.:h')
+        let buf.relativedir = fnamemodify(slashed_path, ':~:.:h')
         let buf.relativename = fnamemodify(buf.fullname, ':~:.')
         return
     endif
@@ -1057,7 +1057,7 @@ function! s:CalculateBufferDetails(buf)
     " effective shortening (`:~`, `:.`), but `:h` is required afterward
     " to trim this separator.
     let buf.homereldir = fnamemodify(parent, ':p:~:h')
-    let buf.relativepath = fnamemodify(parent, ':p:~:.:h')
+    let buf.relativedir = fnamemodify(parent, ':p:~:.:h')
 endfunction
 
 " GetBufferInfo {{{2
@@ -1168,7 +1168,7 @@ function! s:BuildBufferList()
 
         " Are we to split the path and file name?
         if g:bufExplorerSplitOutPathName
-            let type = (g:bufExplorerShowRelativePath) ? "relativepath" : "homereldir"
+            let type = (g:bufExplorerShowRelativePath) ? "relativedir" : "homereldir"
             let row += [buf.shortname, buf[type]]
         else
             let type = (g:bufExplorerShowRelativePath) ? "relativename" : "homename"

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1129,6 +1129,12 @@ endfunction
 
 " BuildBufferList {{{2
 function! s:BuildBufferList()
+    if exists('#User#BufExplorer_PreDisplay')
+        " Notify that BufExplorer is about to display the buffer list.  This is
+        " an opportunity to make last-minute changes to `g:bufExplorerColumns`.
+        doautocmd User BufExplorer_PreDisplay
+    endif
+
     let columns = s:GetColumns()
     let table = []
     let s:displayedBufNbrs = []

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -977,7 +977,7 @@ function! s:CalculateBufferDetails(buf)
         "   !C:\Windows\system32\cmd.exe
 
         " Use the terminal's current working directory as `fulldir`.
-        " For `shortname`, use `!PID:shellName`, prefixed with `!` as Vim does,
+        " For `name`, use `!PID:shellName`, prefixed with `!` as Vim does,
         " and without the shell's dir path for brevity, e.g.:
         "   `/bin/bash` -> `!bash`
         "   `1464953:/bin/bash` -> `!1464953:bash`
@@ -1008,9 +1008,9 @@ function! s:CalculateBufferDetails(buf)
         endif
 
         if pid < 0
-            let shortname = '!' . shellName
+            let name = '!' . shellName
         else
-            let shortname = '!' . pid . ':' . shellName
+            let name = '!' . pid . ':' . shellName
             " On some systems having a `/proc` filesystem (e.g., Linux, *BSD,
             " Solaris), each process has a `cwd` symlink for the current working
             " directory.  `resolve()` will return the actual current working
@@ -1024,8 +1024,8 @@ function! s:CalculateBufferDetails(buf)
         endif
 
         let slashed_path = fnamemodify(cwd, ':p')
-        let buf.fullpath = slashed_path . shortname
-        let buf.shortname = shortname
+        let buf.fullpath = slashed_path . name
+        let buf.name = name
         let buf.homereldir = fnamemodify(slashed_path, ':~:h')
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
         let buf.relativedir = fnamemodify(slashed_path, ':~:.:h')
@@ -1039,17 +1039,17 @@ function! s:CalculateBufferDetails(buf)
         " removed via the first `:h` applied to `buf.fullpath` (except
         " for the root directory, where the path separator will remain).
         let parent = fnamemodify(buf.fullpath, ':h:h')
-        let buf.shortname = fnamemodify(buf.fullpath, ':h:t')
+        let buf.name = fnamemodify(buf.fullpath, ':h:t')
         " Special case for root directory: fnamemodify('/', ':h:t') == ''
-        if buf.shortname == ''
-            let buf.shortname = '.'
+        if buf.name == ''
+            let buf.name = '.'
         endif
         " Must perform shortening (`:~`, `:.`) before `:h`.
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~:h')
         let buf.relativepath = fnamemodify(buf.fullpath, ':~:.:h')
     else
         let parent = fnamemodify(buf.fullpath, ':h')
-        let buf.shortname = fnamemodify(buf.fullpath, ':t')
+        let buf.name = fnamemodify(buf.fullpath, ':t')
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
         let buf.relativepath = fnamemodify(buf.fullpath, ':~:.')
     endif
@@ -1169,7 +1169,7 @@ function! s:BuildBufferList()
         " Are we to split the path and file name?
         if g:bufExplorerSplitOutPathName
             let type = (g:bufExplorerShowRelativePath) ? "relativedir" : "homereldir"
-            let row += [buf.shortname, buf[type]]
+            let row += [buf.name, buf[type]]
         else
             let type = (g:bufExplorerShowRelativePath) ? "relativepath" : "homerelpath"
             let row += [buf[type]]
@@ -1589,7 +1589,7 @@ endfunction
 function! s:Key_name(line)
     let bufNbr = str2nr(a:line)
     let buf = s:raw_buffer_listing[bufNbr]
-    let key = [buf.shortname, buf.fullpath]
+    let key = [buf.name, buf.fullpath]
     return key
 endfunction
 
@@ -1605,8 +1605,8 @@ endfunction
 function! s:Key_extension(line)
     let bufNbr = str2nr(a:line)
     let buf = s:raw_buffer_listing[bufNbr]
-    let extension = fnamemodify(buf.shortname, ':e')
-    let key = [extension, buf.shortname, buf.fullpath]
+    let extension = fnamemodify(buf.name, ':e')
+    let key = [extension, buf.name, buf.fullpath]
     return key
 endfunction
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -891,8 +891,11 @@ function! s:GetHelpStatus()
     let ret .= ((g:bufExplorerShowUnlisted == 0) ? "" : " | Show unlisted")
     let ret .= ((g:bufExplorerShowTabBuffer == 0) ? "" : " | Show buffers/tab")
     let ret .= ((g:bufExplorerOnlyOneTab == 0) ? "" : " | One tab/buffer")
-    let ret .= ' | '.((g:bufExplorerShowRelativePath == 0) ? "Absolute" : "Relative")
-    let ret .= ' '.((g:bufExplorerSplitOutPathName == 0) ? "Full" : "Split")." path"
+    let ret .= ' | '
+    if g:bufExplorerShowRelativePath
+        let ret .= "Relative "
+    endif
+    let ret .= ((g:bufExplorerSplitOutPathName == 0) ? "Whole" : "Split")." path"
     let ret .= ((g:bufExplorerShowTerminal == 0) ? "" : " | Show terminal")
 
     return ret
@@ -921,10 +924,10 @@ function! s:CreateHelp()
         call add(header, '" F : open buffer in another window above the current')
         call add(header, '" f : open buffer in another window below the current')
         call add(header, '" O : open buffer in original window')
-        call add(header, '" p : toggle splitting of file and path name')
+        call add(header, '" p : toggle splitting of path into name + dir')
         call add(header, '" q : quit')
         call add(header, '" r : reverse sort')
-        call add(header, '" R : toggle showing relative or full paths')
+        call add(header, '" R : toggle showing relative paths')
         call add(header, '" s : cycle thru "sort by" fields '.string(s:sort_by).'')
         call add(header, '" S : reverse cycle thru "sort by" fields')
         call add(header, '" T : toggle showing all buffers/only buffers used on this tab')

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -141,7 +141,6 @@ let s:bufExplorerBuffer = 0
 let s:running = 0
 let s:sort_by = ["number", "name", "fullpath", "mru", "extension"]
 let s:didSplit = 0
-let s:types = ["fullname", "homename", "path", "relativename", "relativepath", "shortname"]
 
 " Setup the autocommands that handle stuff. {{{2
 augroup BufExplorer

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -964,27 +964,27 @@ function! s:CalculateBufferDetails(buf)
     endif
     let buf.isterminal = getbufvar(buf.bufNbr, '&buftype') == 'terminal'
     if buf.isterminal
-        " Neovim uses paths with `term://` prefix, where the provided path
+        " Neovim uses paths with `term://` prefix, where the provided dir path
         " is the current working directory when the terminal was launched, e.g.:
         " - Unix:
         "   term://~/tmp/sort//1464953:/bin/bash
         " - Windows:
         "   term://C:\apps\nvim-win64\bin//6408:C:\Windows\system32\cmd.exe
-        " Vim uses paths starting with `!`, with no provided path, e.g.:
+        " Vim uses paths starting with `!`, with no provided dir path, e.g.:
         " - Unix:
         "   !/bin/bash
         " - Windows:
         "   !C:\Windows\system32\cmd.exe
 
-        " Use the terminal's current working directory as the `path`.
+        " Use the terminal's current working directory as `fulldir`.
         " For `shortname`, use `!PID:shellName`, prefixed with `!` as Vim does,
-        " and without the shell's path for brevity, e.g.:
+        " and without the shell's dir path for brevity, e.g.:
         "   `/bin/bash` -> `!bash`
         "   `1464953:/bin/bash` -> `!1464953:bash`
         "   `C:\Windows\system32\cmd.exe` -> `!cmd.exe`
         "   `6408:C:\Windows\system32\cmd.exe` -> `!6408:cmd.exe`
 
-        " Neovim-style name format:
+        " Neovim-style path format:
         "   term://(cwd)//(pid):(shellPath)
         " e.g.:
         "   term://~/tmp/sort//1464953:/bin/bash
@@ -1027,7 +1027,7 @@ function! s:CalculateBufferDetails(buf)
         let buf.fullname = slashed_path . shortname
         let buf.shortname = shortname
         let homepath = fnamemodify(slashed_path, ':~:h')
-        let buf.path = homepath
+        let buf.homereldir = homepath
         let buf.homename = fnamemodify(buf.fullname, ':~')
         let buf.relativepath = fnamemodify(slashed_path, ':~:.:h')
         let buf.relativename = fnamemodify(buf.fullname, ':~:.')
@@ -1057,7 +1057,7 @@ function! s:CalculateBufferDetails(buf)
     " `:p` on `parent` adds back the path separator which permits more
     " effective shortening (`:~`, `:.`), but `:h` is required afterward
     " to trim this separator.
-    let buf.path = fnamemodify(parent, ':p:~:h')
+    let buf.homereldir = fnamemodify(parent, ':p:~:h')
     let buf.relativepath = fnamemodify(parent, ':p:~:.:h')
 endfunction
 
@@ -1169,7 +1169,7 @@ function! s:BuildBufferList()
 
         " Are we to split the path and file name?
         if g:bufExplorerSplitOutPathName
-            let type = (g:bufExplorerShowRelativePath) ? "relativepath" : "path"
+            let type = (g:bufExplorerShowRelativePath) ? "relativepath" : "homereldir"
             let row += [buf.shortname, buf[type]]
         else
             let type = (g:bufExplorerShowRelativePath) ? "relativename" : "homename"

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1709,11 +1709,11 @@ endfunction
 " GetBufNbrAtLine {{{2
 " Return `bufNbr` at `lineNbr`; return 0 if no buffer on that line.
 function! s:GetBufNbrAtLine(lineNbr)
-    if a:lineNbr < s:firstBufferLine || a:lineNbr > s:BufferNumLines()
+    let bufIndex = a:lineNbr - s:firstBufferLine
+    if bufIndex < 0 || bufIndex >= len(s:displayedBufNbrs)
         return 0
     endif
-    let lineText = getline(a:lineNbr)
-    return str2nr(lineText)
+    return s:displayedBufNbrs[bufIndex]
 endfunction
 
 " BufferNumLines {{{2

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1026,6 +1026,7 @@ function! s:CalculateBufferDetails(buf)
 
         let slashed_path = fnamemodify(cwd, ':p')
         let buf.fullpath = slashed_path . name
+        let buf.fulldir = fnamemodify(slashed_path, ':h')
         let buf.name = name
         let buf.homereldir = fnamemodify(slashed_path, ':~:h')
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
@@ -1054,6 +1055,7 @@ function! s:CalculateBufferDetails(buf)
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
         let buf.relativepath = fnamemodify(buf.fullpath, ':~:.')
     endif
+    let buf.fulldir = parent
     " `:p` on `parent` adds back the path separator which permits more
     " effective shortening (`:~`, `:.`), but `:h` is required afterward
     " to trim this separator.

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -649,6 +649,7 @@ function! BufExplorer(...)
         let name = escape(name, "[]")
     endif
 
+    let s:bufNbrAtLaunch = bufnr('%')
     let s:tabIdAtLaunch = s:MRUEnsureTabId(tabpagenr())
     let s:windowAtLaunch = winnr()
 
@@ -698,9 +699,12 @@ function! BufExplorer(...)
     call s:DisplayBufferList()
 
     " Position the cursor in the newly displayed list on the line representing
-    " the active buffer.  The active buffer is the line with the '%' character
-    " in it.
-    execute search("%")
+    " the active buffer at BufExplorer launch (assuming it is displayed).
+    let activeBufIndex = index(s:displayedBufNbrs, s:bufNbrAtLaunch)
+    if activeBufIndex >= 0
+        let activeBufLineNbr = s:firstBufferLine + activeBufIndex
+        keepjumps execute 'normal! ' . string(activeBufLineNbr) . 'G'
+    endif
 
     if exists('#User#BufExplorer_Started')
         " Notify that BufExplorer has started.  This is an opportunity to make
@@ -708,6 +712,9 @@ function! BufExplorer(...)
         doautocmd User BufExplorer_Started
     endif
 endfunction
+
+" Tracks buffer number at BufExplorer launch.
+let s:bufNbrAtLaunch = 0
 
 " Tracks `tabId` at BufExplorer launch.
 let s:tabIdAtLaunch = ''

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1593,7 +1593,7 @@ endfunction
 
 " Key_number {{{2
 function! s:Key_number(buf)
-    let key = [printf('%9d', a:buf.bufNbr)]
+    let key = [printf('%020d', a:buf.bufNbr)]
     return key
 endfunction
 

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1214,6 +1214,10 @@ function! s:MakeLines(table)
     let lines = []
     " To avoid trailing whitespace, do not pad the final column.
     let numColumnsToPad = len(a:table[0]) - 1
+    " Ensure correctness even if `table` has no columns.
+    if numColumnsToPad < 0
+        let numColumnsToPad = 0
+    endif
     let maxWidths = repeat([0], numColumnsToPad)
     for row in a:table
         let i = 0

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1029,7 +1029,7 @@ function! s:CalculateBufferDetails(buf)
         let buf.homereldir = fnamemodify(slashed_path, ':~:h')
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
         let buf.relativedir = fnamemodify(slashed_path, ':~:.:h')
-        let buf.relativename = fnamemodify(buf.fullpath, ':~:.')
+        let buf.relativepath = fnamemodify(buf.fullpath, ':~:.')
         return
     endif
 
@@ -1046,12 +1046,12 @@ function! s:CalculateBufferDetails(buf)
         endif
         " Must perform shortening (`:~`, `:.`) before `:h`.
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~:h')
-        let buf.relativename = fnamemodify(buf.fullpath, ':~:.:h')
+        let buf.relativepath = fnamemodify(buf.fullpath, ':~:.:h')
     else
         let parent = fnamemodify(buf.fullpath, ':h')
         let buf.shortname = fnamemodify(buf.fullpath, ':t')
         let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
-        let buf.relativename = fnamemodify(buf.fullpath, ':~:.')
+        let buf.relativepath = fnamemodify(buf.fullpath, ':~:.')
     endif
     " `:p` on `parent` adds back the path separator which permits more
     " effective shortening (`:~`, `:.`), but `:h` is required afterward
@@ -1171,7 +1171,7 @@ function! s:BuildBufferList()
             let type = (g:bufExplorerShowRelativePath) ? "relativedir" : "homereldir"
             let row += [buf.shortname, buf[type]]
         else
-            let type = (g:bufExplorerShowRelativePath) ? "relativename" : "homerelpath"
+            let type = (g:bufExplorerShowRelativePath) ? "relativepath" : "homerelpath"
             let row += [buf[type]]
         endif
         let row += [buf.line]

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1035,26 +1035,27 @@ function! s:CalculateBufferDetails(buf)
         return
     endif
 
-    let buf.fullpath = simplify(fnamemodify(rawpath, ':p'))
+    let fullpath = simplify(fnamemodify(rawpath, ':p'))
     if buf.isdir
-        " `buf.fullpath` ends with a path separator; this will be
-        " removed via the first `:h` applied to `buf.fullpath` (except
+        " `fullpath` ends with a path separator; this will be
+        " removed via the first `:h` applied to `fullpath` (except
         " for the root directory, where the path separator will remain).
-        let parent = fnamemodify(buf.fullpath, ':h:h')
-        let buf.name = fnamemodify(buf.fullpath, ':h:t')
+        let parent = fnamemodify(fullpath, ':h:h')
+        let buf.name = fnamemodify(fullpath, ':h:t')
         " Special case for root directory: fnamemodify('/', ':h:t') == ''
         if buf.name == ''
             let buf.name = '.'
         endif
         " Must perform shortening (`:~`, `:.`) before `:h`.
-        let buf.homerelpath = fnamemodify(buf.fullpath, ':~:h')
-        let buf.relativepath = fnamemodify(buf.fullpath, ':~:.:h')
+        let buf.homerelpath = fnamemodify(fullpath, ':~:h')
+        let buf.relativepath = fnamemodify(fullpath, ':~:.:h')
     else
-        let parent = fnamemodify(buf.fullpath, ':h')
-        let buf.name = fnamemodify(buf.fullpath, ':t')
-        let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
-        let buf.relativepath = fnamemodify(buf.fullpath, ':~:.')
+        let parent = fnamemodify(fullpath, ':h')
+        let buf.name = fnamemodify(fullpath, ':t')
+        let buf.homerelpath = fnamemodify(fullpath, ':~')
+        let buf.relativepath = fnamemodify(fullpath, ':~:.')
     endif
+    let buf.fullpath = fullpath
     let buf.fulldir = parent
     " `:p` on `parent` adds back the path separator which permits more
     " effective shortening (`:~`, `:.`), but `:h` is required afterward

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -742,6 +742,13 @@ function! s:DisplayBufferList()
     setlocal nomodifiable
 endfunction
 
+" BufExplorer_redisplay {{{2
+function! BufExplorer_redisplay()
+    if s:running && bufnr('%') == s:bufExplorerBuffer
+        call s:RedisplayBufferList()
+    endif
+endfunction
+
 " RedisplayBufferList {{{2
 function! s:RedisplayBufferList()
     call s:RebuildBufferList()

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -133,6 +133,40 @@ function! s:Set(var, default)
     return 0
 endfunction
 
+" Naming conventions for file paths.
+" Conventionally a `path` is the string of characters used to identify a file
+" (ref. https://en.wikipedia.org/wiki/Path_(computing)).
+" An absolute or `full` path starts from the root directory and consists of
+" parent directories (if any) and a final `name` component.
+" A file's `dir` (directory) is the path to the parent directory of the file.
+" In general:
+"
+"   fullpath = dir / name
+"
+" Paths below the user's home directory may be abbreviated, replacing the home
+" directory with `~`, e.g.:
+"
+"   /home/user/some/file
+"   ->
+"   ~/some/file
+"
+" `homerel` refers to paths with home-directory-relative abbreviation.
+"
+" `relative` refers to paths computed relative to the current working directory;
+" these also include the home-directory-relative abbreviation.
+"
+" `rawpath` is the path as returned from `:buffers`; as such, buffers lacking
+" any name are represented as `[No Name]`.
+"
+" Thus, for a buffer:
+" - `rawpath` is the path as returned from `:buffers`.
+" - `fullpath` is the absolute path to the buffer.
+" - `homerelpath` is `fullpath` with the `~/` abbreviation.
+" - `relativepath` is `homerelpath` with relative abbreviation.
+" - `fulldir` is the absolute path to the buffer's parent directory.
+" - `homereldir` is `fulldir` with the `~/` abbreviation.
+" - `relativedir` is `homereldir` with relative abbreviation.
+
 " Script variables {{{2
 let s:MRU_Exclude_List = ["[BufExplorer]","__MRU_Files__","[Buf\ List]"]
 let s:name = '[BufExplorer]'

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1024,34 +1024,34 @@ function! s:CalculateBufferDetails(buf)
         endif
 
         let slashed_path = fnamemodify(cwd, ':p')
-        let buf.fullname = slashed_path . shortname
+        let buf.fullpath = slashed_path . shortname
         let buf.shortname = shortname
         let buf.homereldir = fnamemodify(slashed_path, ':~:h')
-        let buf.homename = fnamemodify(buf.fullname, ':~')
+        let buf.homename = fnamemodify(buf.fullpath, ':~')
         let buf.relativedir = fnamemodify(slashed_path, ':~:.:h')
-        let buf.relativename = fnamemodify(buf.fullname, ':~:.')
+        let buf.relativename = fnamemodify(buf.fullpath, ':~:.')
         return
     endif
 
-    let buf.fullname = simplify(fnamemodify(rawpath, ':p'))
+    let buf.fullpath = simplify(fnamemodify(rawpath, ':p'))
     if buf.isdir
-        " `buf.fullname` ends with a path separator; this will be
-        " removed via the first `:h` applied to `buf.fullname` (except
+        " `buf.fullpath` ends with a path separator; this will be
+        " removed via the first `:h` applied to `buf.fullpath` (except
         " for the root directory, where the path separator will remain).
-        let parent = fnamemodify(buf.fullname, ':h:h')
-        let buf.shortname = fnamemodify(buf.fullname, ':h:t')
+        let parent = fnamemodify(buf.fullpath, ':h:h')
+        let buf.shortname = fnamemodify(buf.fullpath, ':h:t')
         " Special case for root directory: fnamemodify('/', ':h:t') == ''
         if buf.shortname == ''
             let buf.shortname = '.'
         endif
         " Must perform shortening (`:~`, `:.`) before `:h`.
-        let buf.homename = fnamemodify(buf.fullname, ':~:h')
-        let buf.relativename = fnamemodify(buf.fullname, ':~:.:h')
+        let buf.homename = fnamemodify(buf.fullpath, ':~:h')
+        let buf.relativename = fnamemodify(buf.fullpath, ':~:.:h')
     else
-        let parent = fnamemodify(buf.fullname, ':h')
-        let buf.shortname = fnamemodify(buf.fullname, ':t')
-        let buf.homename = fnamemodify(buf.fullname, ':~')
-        let buf.relativename = fnamemodify(buf.fullname, ':~:.')
+        let parent = fnamemodify(buf.fullpath, ':h')
+        let buf.shortname = fnamemodify(buf.fullpath, ':t')
+        let buf.homename = fnamemodify(buf.fullpath, ':~')
+        let buf.relativename = fnamemodify(buf.fullpath, ':~:.')
     endif
     " `:p` on `parent` adds back the path separator which permits more
     " effective shortening (`:~`, `:.`), but `:h` is required afterward
@@ -1121,7 +1121,7 @@ function! s:BuildBufferList()
     " Loop through every buffer.
     for buf in values(s:raw_buffer_listing)
         " `buf.attributes` must exist, but we defer the expensive work of
-        " calculating other buffer details (e.g., `buf.fullname`) until we know
+        " calculating other buffer details (e.g., `buf.fullpath`) until we know
         " the user wants to view this buffer.
 
         " Skip BufExplorer's buffer.
@@ -1136,7 +1136,7 @@ function! s:BuildBufferList()
         endif
 
         " Ensure buffer details are computed for this buffer.
-        if !has_key(buf, 'fullname')
+        if !has_key(buf, 'fullpath')
             call s:CalculateBufferDetails(buf)
         endif
 
@@ -1163,7 +1163,7 @@ function! s:BuildBufferList()
         let row = [buf.attributes]
 
         if exists("g:loaded_webdevicons")
-            let row += [WebDevIconsGetFileTypeSymbol(buf.fullname, buf.isdir)]
+            let row += [WebDevIconsGetFileTypeSymbol(buf.fullpath, buf.isdir)]
         endif
 
         " Are we to split the path and file name?
@@ -1589,7 +1589,7 @@ endfunction
 function! s:Key_name(line)
     let bufNbr = str2nr(a:line)
     let buf = s:raw_buffer_listing[bufNbr]
-    let key = [buf.shortname, buf.fullname]
+    let key = [buf.shortname, buf.fullpath]
     return key
 endfunction
 
@@ -1597,7 +1597,7 @@ endfunction
 function! s:Key_fullpath(line)
     let bufNbr = str2nr(a:line)
     let buf = s:raw_buffer_listing[bufNbr]
-    let key = [buf.fullname]
+    let key = [buf.fullpath]
     return key
 endfunction
 
@@ -1606,7 +1606,7 @@ function! s:Key_extension(line)
     let bufNbr = str2nr(a:line)
     let buf = s:raw_buffer_listing[bufNbr]
     let extension = fnamemodify(buf.shortname, ':e')
-    let key = [extension, buf.shortname, buf.fullname]
+    let key = [extension, buf.shortname, buf.fullpath]
     return key
 endfunction
 
@@ -1615,7 +1615,7 @@ function! s:Key_mru(line)
     let bufNbr = str2nr(a:line)
     let buf = s:raw_buffer_listing[bufNbr]
     let pos = s:MRUOrderForBuf(bufNbr)
-    return [printf('%9d', pos), buf.fullname]
+    return [printf('%9d', pos), buf.fullpath]
 endfunction
 
 " SortByKeyFunc {{{2

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1130,6 +1130,7 @@ endfunction
 " BuildBufferList {{{2
 function! s:BuildBufferList()
     let table = []
+    let s:displayedBufNbrs = []
 
     " Loop through every buffer.
     for buf in values(s:raw_buffer_listing)
@@ -1189,6 +1190,7 @@ function! s:BuildBufferList()
         endif
         let row += [buf.line]
         call add(table, row)
+        call add(s:displayedBufNbrs, buf.bufNbr)
     endfor
 
     let lines = s:MakeLines(table)
@@ -1200,6 +1202,9 @@ function! s:BuildBufferList()
     endif
     call s:SortListing()
 endfunction
+
+" Buffer numbers for buffers displayed in the BufExplorer window.
+let s:displayedBufNbrs = []
 
 " MakeLines {{{2
 function! s:MakeLines(table)

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1026,8 +1026,7 @@ function! s:CalculateBufferDetails(buf)
         let slashed_path = fnamemodify(cwd, ':p')
         let buf.fullname = slashed_path . shortname
         let buf.shortname = shortname
-        let homepath = fnamemodify(slashed_path, ':~:h')
-        let buf.homereldir = homepath
+        let buf.homereldir = fnamemodify(slashed_path, ':~:h')
         let buf.homename = fnamemodify(buf.fullname, ':~')
         let buf.relativepath = fnamemodify(slashed_path, ':~:.:h')
         let buf.relativename = fnamemodify(buf.fullname, ':~:.')

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1027,7 +1027,7 @@ function! s:CalculateBufferDetails(buf)
         let buf.fullpath = slashed_path . shortname
         let buf.shortname = shortname
         let buf.homereldir = fnamemodify(slashed_path, ':~:h')
-        let buf.homename = fnamemodify(buf.fullpath, ':~')
+        let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
         let buf.relativedir = fnamemodify(slashed_path, ':~:.:h')
         let buf.relativename = fnamemodify(buf.fullpath, ':~:.')
         return
@@ -1045,12 +1045,12 @@ function! s:CalculateBufferDetails(buf)
             let buf.shortname = '.'
         endif
         " Must perform shortening (`:~`, `:.`) before `:h`.
-        let buf.homename = fnamemodify(buf.fullpath, ':~:h')
+        let buf.homerelpath = fnamemodify(buf.fullpath, ':~:h')
         let buf.relativename = fnamemodify(buf.fullpath, ':~:.:h')
     else
         let parent = fnamemodify(buf.fullpath, ':h')
         let buf.shortname = fnamemodify(buf.fullpath, ':t')
-        let buf.homename = fnamemodify(buf.fullpath, ':~')
+        let buf.homerelpath = fnamemodify(buf.fullpath, ':~')
         let buf.relativename = fnamemodify(buf.fullpath, ':~:.')
     endif
     " `:p` on `parent` adds back the path separator which permits more
@@ -1171,7 +1171,7 @@ function! s:BuildBufferList()
             let type = (g:bufExplorerShowRelativePath) ? "relativedir" : "homereldir"
             let row += [buf.shortname, buf[type]]
         else
-            let type = (g:bufExplorerShowRelativePath) ? "relativename" : "homename"
+            let type = (g:bufExplorerShowRelativePath) ? "relativename" : "homerelpath"
             let row += [buf[type]]
         endif
         let row += [buf.line]

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -954,6 +954,8 @@ endfunction
 " - `.line`
 function! s:CalculateBufferDetails(buf)
     let buf = a:buf
+    let buf.number = string(buf.bufNbr)
+    let buf.indicators = substitute(buf.numberindicators, '^\s*\d*', '', '')
     let rawpath = bufname(buf.bufNbr)
     let buf["hasNoName"] = empty(rawpath)
     if buf.hasNoName


### PR DESCRIPTION
# Summary

- Addresses issue #114.

- The new variable `g:bufExplorerColumns` holds a customizable list of column strings that dictate the columns in the buffer listing.

- Predefined column string values for `g:bufExplorerColumns`:

  ```
  number
  indicators
  numberindicators
  line
  rawpath
  name
  fullpath
  fulldir
  homerelpath
  homereldir
  relativepath
  relativedir
  path
  dir
  splittablepath
  icon
  ```

- The new function `BufExplorer_redisplay()` causes BufExplorer to redisplay the buffer list according to the columns defined by `g:bufExplorerColumns`.

- The new event `BufExplorer_PreDisplay` will be sent before each update to the buffer listing, enabling last-minute adjustments to the columns.

- Setting `g:bufExplorerColumns` is sufficient to choose any subset of the predefined columns, e.g.:

  ```vim

  " Show only the buffer number and path.
  let g:bufExplorerColumns = ['number', 'splittablepath']

  " Show only the buffer path.
  let g:bufExplorerColumns = ['splittablepath']
  ```

- More dynamic configuration changes are possible as shown in the help text, e.g.:

  - Press `q` to toggle between the default view and showing only the path.
  - Press `=` to reset to preferred settings and redisplay.
  - Press `R` to cycle among `homerel`, `relative`, and `full` prefixes instead of just toggling between `homerel` and `relative`.

- See `:help g:bufExplorerColumns` for more details.

# Details

To support end-user of columns requires exposing a set of buffer properties.  Names for these properties were chosen for consistency with existing names exposed by BufExplorer and with standard industry naming conventions.

For a file[^1]:
- A "path" is the location of the file.
- A "dir" is the directory portion of a path.
- A "name" is a path with the directory portion removed.

A "full" or "absolute" path is the location starting from the root directory.

A "relative" path starts from the current working directory.

Sometimes paths may be abbreviated; for example, paths prefixed by the home directory may be shortened by replacing that prefix with `~/`.  This abbreviation is denoted by the coined term "homerel".

These terms are consistent with BufExplorer's existing user-visible names:

- The sorting terms `fullpath` and `name` used by `g:bufExplorerSortBy` follow the above convention.

- `g:bufExplorerShowRelativePath` applies as defined above to paths for files and directories.

- `g:bufExplorerShowNoName` uses the word `name` as above.

- `g:bufExplorerSplitOutPathName` controls splitting a path as defined above.  Perhaps it would be slightly better named `g:bufExplorerSplitPath` to avoid muddying the waters with the word "name", but it's not far wrong and backward compatibility is important to maintain here.

BufExplorer internals have been adjusted to match the above conventions.

[^1]: <https://en.wikipedia.org/wiki/Path_(computing)>)
