### PR TITLE
Fix regression in splitting behavior.

### DIFF
--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -695,27 +695,36 @@ function! BufExplorer(...)
     call s:MRUGarbageCollectBufs()
     call s:MRUGarbageCollectTabs()
 
+    let [splitbelow, splitright] = [g:bufExplorerSplitBelow, g:bufExplorerSplitRight]
     " `{ action: [splitMode, botRight] }`.
     let actionMap = {
-            \ 'split'   : ['split', g:bufExplorerSplitBelow],
-            \ 'vsplit'  : ['vsplit', g:bufExplorerSplitRight],
-            \ 'above'   : ['split', 0],
-            \ 'below'   : ['split', 1],
-            \ 'left'    : ['vsplit', 0],
-            \ 'right'   : ['vsplit', 1],
-            \ 'current' : ['', 0],
+            \ 'split'   : ['split', splitbelow, splitright],
+            \ 'vsplit'  : ['vsplit', splitbelow, splitright],
+            \ 'above'   : ['split', 0, splitright],
+            \ 'below'   : ['split', 1, splitright],
+            \ 'left'    : ['vsplit', splitbelow, 0],
+            \ 'right'   : ['vsplit', splitbelow, 1],
+            \ 'current' : ['', splitbelow, splitright],
             \}
-    let [splitMode, botRight] = actionMap[action]
+    let [splitMode, splitbelow, splitright] = actionMap[action]
 
     " We may have to split the current window.
     if splitMode != ''
+        " Save off the original settings.
+        let [_splitbelow, _splitright] = [&splitbelow, &splitright]
+
+        " Set the setting to ours.
+        let [&splitbelow, &splitright] = [splitbelow, splitright]
         let size = splitMode == 'split' ? g:bufExplorerSplitHorzSize : g:bufExplorerSplitVertSize
-        let cmd = 'keepalt ' . (botRight ? 'botright ' : 'topleft ')
+        let cmd = 'keepalt '
         if size > 0
             let cmd .= size
         endif
         let cmd .= splitMode
         execute cmd
+
+        " Restore the original settings.
+        let [&splitbelow, &splitright] = [_splitbelow, _splitright]
 
         " Remember that a split was triggered
         let s:didSplit = 1

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -1580,6 +1580,12 @@ function! s:Close()
     " If we needed to split the main window, close the split one.
     if s:didSplit
         execute "wincmd c"
+        " After closing the BufExplorer split, we expect to be back on the
+        " tab from which we launched; if so, make sure we also return to the
+        " window from which we launched.
+        if s:MRUEnsureTabId(tabpagenr()) == s:tabIdAtLaunch
+            execute s:windowAtLaunch . "wincmd w"
+        endif
     endif
 
     " Check to see if there are anymore buffers listed.


### PR DESCRIPTION
Fix regression in splitting behavior.

# Overview

- Restore BufExplorer window-splitting logic.

- When BufExplorer closes via `q`, ensure the original window-at-launch is chosen regardless of split mode.

# Details

This fixes a window-splitting regression I introduced in BufExplorer 7.10.0.

Symptom: Opening BufExplorer in a split above/below/right/left when the window at launch is not topmost/bottommost/rightmost/leftmost, respectively, causes BufExplorer to open a split window at the extreme topmost/bottommost/rightmost/leftmost position instead of a position next to the window at launch.  In addition, when closing BufExplorer, instead of focusing the original window at launch, it incorrectly focuses the window adjacent to the extreme window that held BufExplorer; then, the original buffer from launch will be restored to the incorrectly focused window.

For example, consider files `one` and `two` opened in horizontal splits via:

```sh
touch one two
vim '+e one|sp two'
```

The buffers are arranged as below, with the cursor in the upper window:

```
<cursor-here>
~
~
~
~
~
~
~
~
~
~
two                        0,0-1          All

~
~
~
~
~
~
~
~
~
one                        0,0-1          All
```

Launching BufExplorer via `:BufExplorer below` should open a split below `two` but above `one`, like this:

```

~
~
~
~
~
~
two                        0,0-1          All
" Press <F1> for Help
" Sorted by mru | Locate buffer | One tab/buf
"=
  2 %a    two ~ line 1
  1 #a    one ~ line 0
~
~
[BufExplorer]              4,3            All

~
~
~
~
~
one                        0,0-1          All
```

Instead, however, BufExplorer is launched in a bottommost split, like this:

```

~
~
~
~
~
~
two                        0,0-1          All

~
~
~
~
~
one                        0,0-1          All
" Press <F1> for Help
" Sorted by mru | Locate buffer | One tab/buf
"=
  2 %a    two ~ line 1
  1 #a    one ~ line 0
~
~
[BufExplorer]              4,3            All
```

Quitting BufExplorer via `q` then results in the window for `one` being focused instead of the original window for `two`; after this, the window is switched to the buffer for file `two`, resulting in:

```

~
~
~
~
~
~
~
~
~
two                        0,0-1          All
<cursor-here>
~
~
~
~
~
~
~
~
~
~
two                        0,0-1          All
```

I'd thought that `:botright split filename` was the same as `:set splitbelow|split filename`; I apologize for not noticing the difference in behavior.  This pull request reverts to the original logic using Vim's 'splitbelow' and 'splitright' options instead of `:botright` and `:topleft`.

However, during testing I noticed that the algorithm in BufExplorer versions prior to 7.10.0 does not always return to the correct window when BufExplorer closes.  With the default BufExplorer options `g:bufExplorerSplitBelow = 0` and `g:bufExplorerSplitRight = 0`, BufExplorer opens "before" (above or left-of) the original window, and when BufExplorer closes via `q`, the correct (original) window is chosen; however, with `g:bufExplorerSplitBelow = 1` and `g:bufExplorerSplitRight = 1`, the wrong window is chosen (namely, the window below or right-of the original).  To see this with BufExplorer 7.4.28, for example:

```sh
vim '+e one|sp two'
```

Note that the topmost window is active as before:

```
<cursor-here>
~
~
~
~
~
~
~
~
~
~
two                        0,0-1          All

~
~
~
~
~
~
~
~
~
one                        0,0-1          All
```

Open a window below via:

```vim
:let g:bufExplorerSplitBelow = 1|BufExplorerHorizontalSplit
```

BufExplorer is shown in the middle window:

```

~
~
~
~
~
~
two                        0,0-1          All
" Press <F1> for Help
" Sorted by mru | Locate buffer | One tab/buf
"=
  2 %a    two ~
  1 #a    one ~
~
~
[BufExplorer]              4,3            All

~
~
~
~
~
one                        0,0-1          All
```

Then close BufExplorer via `q`, resulting in:

```

~
~
~
~
~
~
~
~
~
two                        0,0-1          All
<cursor-here>
~
~
~
~
~
~
~
~
~
~
two                        0,0-1          All
```

The bottommost window is incorrectly chosen, and the buffer for file `two` is incorrectly restored to this window.

This pull request therefore also includes logic to restore the window-at-launch when BufExplorer closes, regardless how the BufExplorer split window is chosen.
