### PR TITLE
Stop ignoring "No Name" buffers in MRU tracking.

### DIFF
--- a/doc/bufexplorer.txt
+++ b/doc/bufexplorer.txt
@@ -616,7 +616,7 @@ The default is to show directories.
 To control whether to show "No Name" buffers or not, use: >
   let g:bufExplorerShowNoName=0        " Do not "No Name" buffers.
   let g:bufExplorerShowNoName=1        " Show "No Name" buffers.
-The default is to NOT show "No Name buffers.
+The default is to NOT show "No Name" buffers.
 
                                                 *g:bufExplorerShowRelativePath*
 To control whether to show paths relative to the current directory, use: >

--- a/plugin/bufexplorer.vim
+++ b/plugin/bufexplorer.vim
@@ -535,11 +535,6 @@ function! s:ShouldIgnore(buf)
         return 1
     endif
 
-    " Ignore buffers with no name.
-    if empty(bufname(a:buf)) == 1
-        return 1
-    endif
-
     " Ignore the BufExplorer buffer.
     if fnamemodify(bufname(a:buf), ":t") == s:name
         return 1


### PR DESCRIPTION
With "No Name" buffers displayed via `g:bufExplorerShowNoName = 1`, BufExplorer can fail to return to the original buffer when `q` is pressed.  For example:

- Start Vim.
- Show "No Name" buffers via `:let g:bufExplorerShowNoName = 1`.
- Insert some text via `ihello<Escape>`.
- Launch BufExplorer via `\be`.
- Notice Buffer 1 is displayed as `[No Name]`.
- Quit BufExplorer with `q`.
- Notice a new (empty) buffer is now displayed, e.g.: `:ls`

      1  h + "[No Name]"                    line 1
      3 %a   "[No Name]"                    line 1

BufExplorer fails to return to the original buffer because it has been ignoring "No Name" buffers for the purposes of MRU tracking.  The MRU system tracks buffers in most-recently-used order, but it does not track buffers where `s:ShouldIgnore()` returns true.  When BufExplorer exits, it tries to return to a buffer in its MRU list.  Since "No Name" buffers aren't tracked, it instead returns to a new buffer.

Historically, `s:ShouldIgnore()` has ignored buffers with `&buftype` set, specially named buffers (e.g., `[BufExplorer]`), and "No Name" buffers. But since "No Name" buffers may be displayed, they should also be MRU-tracked.  Removing the check in `s:ShouldIgnore()` for "No Name" buffers fixes the above issue.  Pressing `q` to exit BufExplorer now returns to the original buffer.
